### PR TITLE
fixed next port when port is not a number.

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -349,7 +349,7 @@ exports.getSocket = function (options, callback) {
 // specified `port`.
 //
 exports.nextPort = function (port) {
-  return port + 1;
+  return Number(port) + 1;
 };
 
 //


### PR DESCRIPTION
When I pass a string port,'nextPort' function will get a unexpected result.