### PR TITLE
Randomize the order in which ports are tested for availability

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -33,18 +33,21 @@ internals.testPort = function(options, callback) {
     //
   });
 
-  debugTestPort("entered testPort(): trying", options.host, "port", options.port);
+  var candidatePorts = Array.from(options.ports)
+  var currentPort  = candidatePorts.pop()
+
+  debugTestPort("entered testPort(): trying", options.host, "port", currentPort);
 
   function onListen () {
-    debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
+    debugTestPort("done w/ testPort(): OK", options.host, "port", currentPort);
 
         options.server.removeListener('error', onError);
         options.server.close();
-      callback(null, options.port);
+      callback(null, currentPort);
   }
 
   function onError (err) {
-    debugTestPort("done w/ testPort(): failed", options.host, "w/ port", options.port, "with error", err.code);
+    debugTestPort("done w/ testPort(): failed", options.host, "w/ port", currentPort, "with error", err.code);
 
     options.server.removeListener('listening', onListen);
 
@@ -52,16 +55,18 @@ internals.testPort = function(options, callback) {
       return callback(err);
     }
 
-    var nextPort = exports.nextPort(options.port);
+    if (candidatePorts.length === 0) {
+      var msg = 'No open ports found in between ' + options.startPort + ' and ' + options.stopPort; 
+      return callback(new Error(msg));
 
-    if (nextPort > exports.highestPort) {
-      return callback(new Error('No open ports available'));
     }
 
     internals.testPort({
-      port: nextPort,
+      ports: candidatePorts,
       host: options.host,
-      server: options.server
+      server: options.server,
+      startPort: options.startPort,
+      stopPort: options.stopPort
     }, callback);
   }
 
@@ -69,14 +74,14 @@ internals.testPort = function(options, callback) {
   options.server.once('listening', onListen);
 
   if (options.host) {
-    options.server.listen(options.port, options.host);
+    options.server.listen(currentPort, options.host);
   } else {
     /*
       Judgement of service without host
       example:
         express().listen(options.port)
     */
-    options.server.listen(options.port);
+    options.server.listen(currentPort);
   }
 };
 
@@ -112,8 +117,7 @@ exports.getPort = function (options, callback) {
   }
 
   options.port   = Number(options.port) || Number(exports.basePort);
-  options.host   = options.host    || null;
-  options.stopPort = Number(options.stopPort) || Number(exports.highestPort);
+  options.host   = options.host || null;
 
   if(!options.startPort) {
     options.startPort = Number(options.port);
@@ -124,6 +128,13 @@ exports.getPort = function (options, callback) {
       throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
     }
   }
+
+  if (!options.stopPort) {
+    options.stopPort = Number(exports.highestPort);
+  } else {
+    options.stopPort = Math.min(options.stopPort, Number(exports.highestPort))
+  }
+
 
   if (options.host) {
 
@@ -141,11 +152,16 @@ exports.getPort = function (options, callback) {
 
   }
 
+  var candidatePorts = []
+  for (i = options.port; i < options.stopPort; i++) {
+    candidatePorts.push(i)
+  }
+  randomShuffle(candidatePorts)
   var openPorts = [], currentHost;
   return async.eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);
 
-    return internals.testPort({ host: host, port: options.port }, function(err, port) {
+    return internals.testPort({ host: host, ports: candidatePorts, startPort: options.startPort, stopPort: options.stopPort }, function(err, port) {
       if (err) {
         debugGetPort("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
         currentHost = host;
@@ -357,6 +373,19 @@ exports.getSocket = function (options, callback) {
 exports.nextPort = function (port) {
   return port + 1;
 };
+
+//
+// ### function RandomShuffle (array)
+// #### @array {Array} array (of ports) to shuffle.
+// Uses the Fisher-Yates algorithm to randomly shuffle
+// the array in linear time. This is performed in-place.
+//
+function randomShuffle(array) {
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
 
 //
 // ### function nextSocket (socketPath)

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -29,10 +29,15 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPorts(3, this.callback);
         },
-        "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
+        "should respond with three distinct available ports (>= 32773)": function (err, ports) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.deepEqual(ports, [32773, 32774, 32775]);
+          var seen = new Set()
+          for (var port of ports) {
+            assert.isFalse(seen.has(port))
+            assert.isTrue(port >= 32773)
+            seen.add(port)
+          }
         }
       }
     }
@@ -51,10 +56,15 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPorts(3, this.callback);
         },
-        "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
+        "should respond with three distinct available ports (>= 32768)": function (err, ports) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.deepEqual(ports, [32768, 32769, 32770]);
+          var seen = new Set()
+          for (var port of ports) {
+            assert.isFalse(seen.has(port))
+            assert.isTrue(port >= 32773)
+            seen.add(port)
+          }
         }
       }
     }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -36,12 +36,12 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort(this.callback);
         },
-        "should respond with the first free port (32773)": function (err, port) {
+        "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
 
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773)
         }
       },
     }
@@ -56,12 +56,12 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort({ host: 'localhost' }, this.callback);
         },
-        "should respond with the first free port (32773)": function (err, port) {
+        "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
 
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773)
         }
       },
     }
@@ -79,7 +79,6 @@ vows.describe('portfinder').addBatch({
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
-
           assert.isTrue(!!err);
           assert.equal(
             err.message,
@@ -99,14 +98,14 @@ vows.describe('portfinder').addBatch({
       "the getPort() method with stopPort greater than available port": {
         topic: function () {
           // stopPort: 32774 is greater than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32774 }, this.callback);
+          portfinder.getPort({ stopPort: 32780 }, this.callback);
         },
-        "should respond with the first free port (32773) less than provided stopPort": function(err, port) {
+        "should respond with a free port less than provided stopPort": function(err, port) {
           closeServers() // close all the servers first!
-
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773);
+          assert.isTrue(port < 32780);
         }
       },
     }
@@ -122,10 +121,10 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort(this.callback);
         },
-        "should respond with the first free port (32768)": function (err, port) {
+        "should respond with a free port (>= 32768)": function (err, port) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32768);
+          assert.isTrue(port >= 32768);
         }
       }
     }
@@ -149,7 +148,7 @@ vows.describe('portfinder').addBatch({
               vow.callback(err, null);
             });
         },
-        "should respond with a promise of first free port (32768) if Promise are available": function (err, port) {
+        "should respond with a promise of a free port (>= 32768) if Promise are available": function (err, port) {
           if (typeof Promise !== 'function') {
             assert.isTrue(!!err);
             assert.equal(
@@ -161,7 +160,7 @@ vows.describe('portfinder').addBatch({
           }
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32768);
+          assert.isTrue(port >= 32768);
         }
       },
     }
@@ -195,7 +194,7 @@ vows.describe('portfinder').addBatch({
           assert.isTrue(!!err);
           assert.equal(
             err.message,
-            'No open ports available'
+            'No open ports found in between 65530 and 65535'
           );
           return;
         }


### PR DESCRIPTION
Addresses https://github.com/http-party/node-portfinder/issues/79 by creating an array of candidate ports to test and randomly shuffling it. The remaining logic is unchanged, except that the check for whether a tested port exceeds the global `highestPort` is moved from `testPort` to `getPort` (i.e. we exclude any port higher than `highestPort` from the initial list of candidate ports).