### PR TITLE
Randomize selection order of tested ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ If `portfinder.getPortPromise()` is called on a Node version without Promise (<4
 
 ### Ports search scope 
 
-By default `portfinder` will start searching from `8000` and scan until maximum port number (`65535`) is reached. 
+By default `portfinder` will start searching from `8000` and scan until maximum port number (`40000`) is reached. `40000` is the highest safe port across platforms. If you are not on OSX, you can safely override the max port up to 65535.
 
 You can change this globally by setting:
 
 ```js
 portfinder.basePort = 3000;    // default: 8000
-portfinder.highestPort = 3333; // default: 65535
+portfinder.highestPort = 3333; // default: 40000; cannot be overriden above 65535
 ```
 
 or by passing optional options object on each invocation:

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -94,8 +94,13 @@ exports.basePort = 8000;
 //
 // ### @highestPort {Number}
 // Largest port number is an unsigned short 2**16 -1=65335
+// To avoid collisions with the MacBook Pro touchbar, which binds
+// to a random port in the range 40,000 - ~60,000, we only search
+// up to 40,000 unless the user explicitly specifies a stopPort higher 
+// than that. In any event, we will not search above _highestPort (65535).
 //
-exports.highestPort = 65535;
+exports.highestPort = 40000; // The safe highest port; user can override to search higher
+var _highestPort = 65535; // The absolute highest port;
 
 //
 // ### @basePath {string}
@@ -113,11 +118,17 @@ exports.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
     options = {};
-
   }
 
   options.port   = Number(options.port) || Number(exports.basePort);
   options.host   = options.host || null;
+
+
+  if (!options.stopPort) {
+    options.stopPort = Number(exports.highestPort);
+  } else {
+    options.stopPort = Math.min(Number(options.stopPort), Number(_highestPort))
+  }
 
   if(!options.startPort) {
     options.startPort = Number(options.port);
@@ -128,13 +139,6 @@ exports.getPort = function (options, callback) {
       throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
     }
   }
-
-  if (!options.stopPort) {
-    options.stopPort = Number(exports.highestPort);
-  } else {
-    options.stopPort = Math.min(options.stopPort, Number(exports.highestPort))
-  }
-
 
   if (options.host) {
 
@@ -259,17 +263,11 @@ exports.getPorts = function (count, options, callback) {
     options = {};
   }
 
-  var lastPort = null;
   async.timesSeries(count, function(index, asyncCallback) {
-    if (lastPort) {
-      options.port = exports.nextPort(lastPort);
-    }
-
     exports.getPort(options, function (err, port) {
       if (err) {
         asyncCallback(err);
       } else {
-        lastPort = port;
         asyncCallback(null, port);
       }
     });
@@ -362,16 +360,6 @@ exports.getSocket = function (options, callback) {
   return options.exists
     ? testSocket()
     : checkAndTestSocket();
-};
-
-//
-// ### function nextPort (port)
-// #### @port {Number} Port to increment from.
-// Gets the next port in sequence from the
-// specified `port`.
-//
-exports.nextPort = function (port) {
-  return port + 1;
 };
 
 //

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -33,18 +33,21 @@ internals.testPort = function(options, callback) {
     //
   });
 
-  debugTestPort("entered testPort(): trying", options.host, "port", options.port);
+  var candidatePorts = Array.from(options.ports)
+  var currentPort  = candidatePorts.pop()
+
+  debugTestPort("entered testPort(): trying", options.host, "port", currentPort);
 
   function onListen () {
-    debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
+    debugTestPort("done w/ testPort(): OK", options.host, "port", currentPort);
 
         options.server.removeListener('error', onError);
         options.server.close();
-      callback(null, options.port);
+      callback(null, currentPort);
   }
 
   function onError (err) {
-    debugTestPort("done w/ testPort(): failed", options.host, "w/ port", options.port, "with error", err.code);
+    debugTestPort("done w/ testPort(): failed", options.host, "w/ port", currentPort, "with error", err.code);
 
     options.server.removeListener('listening', onListen);
 
@@ -52,16 +55,18 @@ internals.testPort = function(options, callback) {
       return callback(err);
     }
 
-    var nextPort = exports.nextPort(options.port);
+    if (candidatePorts.length === 0) {
+      var msg = 'No open ports found in between ' + options.startPort + ' and ' + options.stopPort; 
+      return callback(new Error(msg));
 
-    if (nextPort > exports.highestPort) {
-      return callback(new Error('No open ports available'));
     }
 
     internals.testPort({
-      port: nextPort,
+      ports: candidatePorts,
       host: options.host,
-      server: options.server
+      server: options.server,
+      startPort: options.startPort,
+      stopPort: options.stopPort
     }, callback);
   }
 
@@ -69,14 +74,14 @@ internals.testPort = function(options, callback) {
   options.server.once('listening', onListen);
 
   if (options.host) {
-    options.server.listen(options.port, options.host);
+    options.server.listen(currentPort, options.host);
   } else {
     /*
       Judgement of service without host
       example:
         express().listen(options.port)
     */
-    options.server.listen(options.port);
+    options.server.listen(currentPort);
   }
 };
 
@@ -112,8 +117,7 @@ exports.getPort = function (options, callback) {
   }
 
   options.port   = Number(options.port) || Number(exports.basePort);
-  options.host   = options.host    || null;
-  options.stopPort = Number(options.stopPort) || Number(exports.highestPort);
+  options.host   = options.host || null;
 
   if(!options.startPort) {
     options.startPort = Number(options.port);
@@ -124,6 +128,13 @@ exports.getPort = function (options, callback) {
       throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
     }
   }
+
+  if (!options.stopPort) {
+    options.stopPort = Number(exports.highestPort);
+  } else {
+    options.stopPort = Math.min(options.stopPort, Number(exports.highestPort))
+  }
+
 
   if (options.host) {
 
@@ -141,11 +152,16 @@ exports.getPort = function (options, callback) {
 
   }
 
+  var candidatePorts = []
+  for (i = options.port; i < options.stopPort; i++) {
+    candidatePorts.push(i)
+  }
+  randomShuffle(candidatePorts)
   var openPorts = [], currentHost;
   return async.eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);
 
-    return internals.testPort({ host: host, port: options.port }, function(err, port) {
+    return internals.testPort({ host: host, ports: candidatePorts, startPort: options.startPort, stopPort: options.stopPort }, function(err, port) {
       if (err) {
         debugGetPort("in eachSeries() iteration callback testPort() callback", "with an err:", err.code);
         currentHost = host;
@@ -357,6 +373,21 @@ exports.getSocket = function (options, callback) {
 exports.nextPort = function (port) {
   return port + 1;
 };
+
+//
+// ### function RandomShuffle (array)
+// #### @array {Array} array (of ports) to shuffle.
+// Uses the Fisher-Yates algorithm to randomly shuffle
+// the array in linear time. This is performed in-place.
+//
+function randomShuffle(array) {
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var tmp = array[i]
+    array[i] = array[j]
+    array[j] = tmp
+  }
+}
 
 //
 // ### function nextSocket (socketPath)

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -33,7 +33,7 @@ internals.testPort = function(options, callback) {
     //
   });
 
-  var candidatePorts = Array.from(options.ports)
+  var candidatePorts = options.ports.slice()
   var currentPort  = candidatePorts.pop()
 
   debugTestPort("entered testPort(): trying", options.host, "port", currentPort);

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -29,10 +29,15 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPorts(3, this.callback);
         },
-        "should respond with the first three available ports (32773, 32774, 32775)": function (err, ports) {
+        "should respond with three distinct available ports (>= 32773)": function (err, ports) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.deepEqual(ports, [32773, 32774, 32775]);
+          var seen = new Set()
+          for (var port of ports) {
+            assert.isFalse(seen.has(port))
+            assert.isTrue(port >= 32773)
+            seen.add(port)
+          }
         }
       }
     }
@@ -51,10 +56,15 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPorts(3, this.callback);
         },
-        "should respond with the first three available ports (32768, 32769, 32770)": function (err, ports) {
+        "should respond with three distinct available ports (>= 32768)": function (err, ports) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.deepEqual(ports, [32768, 32769, 32770]);
+          var seen = new Set()
+          for (var port of ports) {
+            assert.isFalse(seen.has(port))
+            assert.isTrue(port >= 32773)
+            seen.add(port)
+          }
         }
       }
     }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -182,11 +182,11 @@ vows.describe('portfinder').addBatch({
   "When using portfinder module": {
     "with no available ports above the start port": {
       topic: function () {
-        testHelper(servers, 65530, 65536, this.callback);
+        testHelper(servers, 39998, 40000, this.callback);
       },
       "the getPort() method requesting an unavailable port": {
         topic: function () {
-          portfinder.getPort({ port: 65530 }, this.callback);
+          portfinder.getPort({ port: 39998 }, this.callback);
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
@@ -194,7 +194,7 @@ vows.describe('portfinder').addBatch({
           assert.isTrue(!!err);
           assert.equal(
             err.message,
-            'No open ports found in between 65530 and 65535'
+            'No open ports found in between 39998 and 40000'
           );
           return;
         }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -36,12 +36,12 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort(this.callback);
         },
-        "should respond with the first free port (32773)": function (err, port) {
+        "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
 
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773)
         }
       },
     }
@@ -56,12 +56,12 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort({ host: 'localhost' }, this.callback);
         },
-        "should respond with the first free port (32773)": function (err, port) {
+        "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
 
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773)
         }
       },
     }
@@ -79,7 +79,6 @@ vows.describe('portfinder').addBatch({
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
-
           assert.isTrue(!!err);
           assert.equal(
             err.message,
@@ -99,14 +98,14 @@ vows.describe('portfinder').addBatch({
       "the getPort() method with stopPort greater than available port": {
         topic: function () {
           // stopPort: 32774 is greater than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32774 }, this.callback);
+          portfinder.getPort({ stopPort: 32780 }, this.callback);
         },
-        "should respond with the first free port (32773) less than provided stopPort": function(err, port) {
+        "should respond with a free port less than provided stopPort": function(err, port) {
           closeServers() // close all the servers first!
-
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32773);
+          assert.isTrue(port >= 32773);
+          assert.isTrue(port < 32780);
         }
       },
     }
@@ -122,10 +121,10 @@ vows.describe('portfinder').addBatch({
         topic: function () {
           portfinder.getPort(this.callback);
         },
-        "should respond with the first free port (32768)": function (err, port) {
+        "should respond with a free port (>= 32768)": function (err, port) {
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32768);
+          assert.isTrue(port >= 32768);
         }
       }
     }
@@ -149,7 +148,7 @@ vows.describe('portfinder').addBatch({
               vow.callback(err, null);
             });
         },
-        "should respond with a promise of first free port (32768) if Promise are available": function (err, port) {
+        "should respond with a promise of a free port (>= 32768) if Promise are available": function (err, port) {
           if (typeof Promise !== 'function') {
             assert.isTrue(!!err);
             assert.equal(
@@ -161,7 +160,7 @@ vows.describe('portfinder').addBatch({
           }
           if (err) { debugVows(err); }
           assert.isTrue(!err);
-          assert.equal(port, 32768);
+          assert.isTrue(port >= 32768);
         }
       },
     }
@@ -195,7 +194,7 @@ vows.describe('portfinder').addBatch({
           assert.isTrue(!!err);
           assert.equal(
             err.message,
-            'No open ports available'
+            'No open ports found in between 65530 and 65535'
           );
           return;
         }


### PR DESCRIPTION
Addresses https://github.com/http-party/node-portfinder/issues/79 by creating an array of candidate ports to test and randomly shuffling it. The remaining logic is unchanged, except that the check for whether a tested port exceeds the global highestPort is moved from testPort to getPort (i.e. we exclude any port higher than highestPort from the initial list of candidate ports).