### PR TITLE
Avoid breaking existing consumers who use startPort >= 40000

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ portfinder.getPort({
 }, callback);
 ```
 
+### Port scan strategy
+
+By default, portfinder will perform a linear scan from the startPort to the stopPort until it has found a free port (or the number of free ports specified in `getPorts`). This can lead to race conditions if `getPort` is called several times in quick succession: the same port may be returned for multiple calls. To avoid this, you can pass `useRandom: true` into the options, in which case ports in the range from `startPort` to `stopPort` will be checked in random order:
+
+```js
+portfinder.getPort({
+    useRandom: true
+}, callback);
+```
+
 ## Run Tests
 ``` bash
   $ npm test

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -392,7 +392,9 @@ function randomShuffle(array) {
 function randomShuffle(array) {
   for (var i = array.length - 1; i > 0; i--) {
     var j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]];
+    var tmp = array[i]
+    array[i] = array[j]
+    array[j] = tmp
   }
 }
 

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -141,14 +141,14 @@ exports.getPort = function (options, callback) {
   }
 
   if (options.startPort > exports.highestPort) {
-    console.warn('Provided options.startPort(' + options.startPort + ') is higher than the recommended stopPort (' + exports.stopPort + '). This may cause issues on some systems');
+    console.warn('Provided options.startPort(' + options.startPort + ') is higher than the recommended stopPort (' + exports.highestPort + '). This may cause issues on some systems');
     if(options.stopPort <= options.startPort) {
       options.stopPort = _highestPort
     }
   }
 
   if(options.stopPort < options.startPort) {
-    throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
+    throw Error('Provided options.stopPort (' + options.stopPort + ') is less than options.startPort (' + options.startPort + ')');
   }
 
   if (options.host) {

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -123,7 +123,6 @@ exports.getPort = function (options, callback) {
   options.port   = Number(options.port) || Number(exports.basePort);
   options.host   = options.host || null;
 
-
   if (!options.stopPort) {
     options.stopPort = Number(exports.highestPort);
   } else {
@@ -139,6 +138,13 @@ exports.getPort = function (options, callback) {
       throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
     }
   }
+
+  if (!options.stopPort) {
+    options.stopPort = Number(exports.highestPort);
+  } else {
+    options.stopPort = Math.min(options.stopPort, Number(exports.highestPort))
+  }
+
 
   if (options.host) {
 
@@ -210,6 +216,8 @@ exports.getPort = function (options, callback) {
 
     debugGetPort("in eachSeries() result callback: openPorts is", openPorts);
 
+
+    
     if (openPorts[0] === openPorts[openPorts.length-1]) {
       // if first === last, we found an open port
       if(openPorts[0] <= options.stopPort) {
@@ -374,6 +382,19 @@ function randomShuffle(array) {
     var tmp = array[i]
     array[i] = array[j]
     array[j] = tmp
+  }
+}
+
+//
+// ### function RandomShuffle (array)
+// #### @array {Array} array (of ports) to shuffle.
+// Uses the Fisher-Yates algorithm to randomly shuffle
+// the array in linear time. This is performed in-place.
+//
+function randomShuffle(array) {
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
   }
 }
 

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -119,10 +119,10 @@ exports.getPort = function (options, callback) {
     callback = options;
     options = {};
   }
-
   options.port   = Number(options.port) || Number(exports.basePort);
   options.host   = options.host || null;
 
+  // Validate startPort and stopPort
   if (!options.stopPort) {
     options.stopPort = Number(exports.highestPort);
   } else {
@@ -134,17 +134,22 @@ exports.getPort = function (options, callback) {
     if(options.startPort < 0) {
       throw Error('Provided options.startPort(' + options.startPort + ') is less than 0, which are cannot be bound.');
     }
-    if(options.stopPort < options.startPort) {
-      throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
+  }
+
+  if (options.startPort > _highestPort) {
+    throw Error('Provided options.startPort(' + options.startPort + ') is higher than the maximum available port (' + _highestPort + ').');
+  }
+
+  if (options.startPort > exports.highestPort) {
+    console.warn('Provided options.startPort(' + options.startPort + ') is higher than the recommended stopPort (' + exports.stopPort + '). This may cause issues on some systems');
+    if(options.stopPort <= options.startPort) {
+      options.stopPort = _highestPort
     }
   }
 
-  if (!options.stopPort) {
-    options.stopPort = Number(exports.highestPort);
-  } else {
-    options.stopPort = Math.min(options.stopPort, Number(exports.highestPort))
+  if(options.stopPort < options.startPort) {
+    throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
   }
-
 
   if (options.host) {
 
@@ -367,21 +372,6 @@ exports.getSocket = function (options, callback) {
     ? testSocket()
     : checkAndTestSocket();
 };
-
-//
-// ### function RandomShuffle (array)
-// #### @array {Array} array (of ports) to shuffle.
-// Uses the Fisher-Yates algorithm to randomly shuffle
-// the array in linear time. This is performed in-place.
-//
-function randomShuffle(array) {
-  for (var i = array.length - 1; i > 0; i--) {
-    var j = Math.floor(Math.random() * (i + 1));
-    var tmp = array[i]
-    array[i] = array[j]
-    array[j] = tmp
-  }
-}
 
 //
 // ### function RandomShuffle (array)

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -168,7 +168,7 @@ exports.getPort = function (options, callback) {
   }
 
   var candidatePorts = []
-  for (i = options.port; i < options.stopPort; i++) {
+  for (i = options.port; i <= options.stopPort; i++) {
     candidatePorts.push(i)
   }
 

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -216,8 +216,6 @@ exports.getPort = function (options, callback) {
 
     debugGetPort("in eachSeries() result callback: openPorts is", openPorts);
 
-
-    
     if (openPorts[0] === openPorts[openPorts.length-1]) {
       // if first === last, we found an open port
       if(openPorts[0] <= options.stopPort) {

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -171,7 +171,12 @@ exports.getPort = function (options, callback) {
   for (i = options.port; i < options.stopPort; i++) {
     candidatePorts.push(i)
   }
-  randomShuffle(candidatePorts)
+
+  if (options.useRandom) {
+    randomShuffle(candidatePorts)
+  } else {
+    candidatePorts.reverse()
+  }
   var openPorts = [], currentHost;
   return async.eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portfinder",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portfinder",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portfinder",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfinder",
   "description": "A simple tool to find an open port on the current machine",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfinder",
   "description": "A simple tool to find an open port on the current machine",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfinder",
   "description": "A simple tool to find an open port on the current machine",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -25,9 +25,9 @@ vows.describe('portfinder').addBatch({
       topic: function () {
         testHelper(servers, this.callback);
       },
-      "the getPorts() method with an argument of 3": {
+      "the getPorts() method with an argument of 3 and useRandom: true": {
         topic: function () {
-          portfinder.getPorts(3, this.callback);
+          portfinder.getPorts(3, {useRandom: true}, this.callback);
         },
         "should respond with three distinct available ports (>= 32773)": function (err, ports) {
           if (err) { debugVows(err); }
@@ -52,9 +52,9 @@ vows.describe('portfinder').addBatch({
 
         return null;
       },
-      "the getPorts() method with an argument of 3": {
+      "the getPorts() method with an argument of 3 and useRandom: true": {
         topic: function () {
-          portfinder.getPorts(3, this.callback);
+          portfinder.getPorts(3, {useRandom: true}, this.callback);
         },
         "should respond with three distinct available ports (>= 32768)": function (err, ports) {
           if (err) { debugVows(err); }

--- a/test/port-finder-random-test.js
+++ b/test/port-finder-random-test.js
@@ -100,12 +100,12 @@ vows.describe('portfinder with useRandom').addBatch({
           // stopPort: 32774 is greater than available port 32773 (32768 + 5)
           portfinder.getPort({ useRandom: true, stopPort: 32780 }, this.callback);
         },
-        "should respond with a free port less than provided stopPort": function(err, port) {
+        "should respond with a free port less than or equal to provided stopPort": function(err, port) {
           closeServers() // close all the servers first!
           if (err) { debugVows(err); }
           assert.isTrue(!err);
           assert.isTrue(port >= 32773);
-          assert.isTrue(port < 32780);
+          assert.isTrue(port <= 32780);
         }
       },
     }

--- a/test/port-finder-random-test.js
+++ b/test/port-finder-random-test.js
@@ -26,7 +26,7 @@ var closeServers = function () {
   servers = []
 }
 
-vows.describe('portfinder').addBatch({
+vows.describe('portfinder with useRandom').addBatch({
   "When using portfinder module": {
     "with 5 existing servers": {
       topic: function () {
@@ -34,7 +34,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          portfinder.getPort(this.callback);
+          portfinder.getPort({useRandom: true}, this.callback);
         },
         "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
@@ -54,7 +54,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method with user passed duplicate host": {
         topic: function () {
-          portfinder.getPort({ host: 'localhost' }, this.callback);
+          portfinder.getPort({ useRandom: true, host: 'localhost' }, this.callback);
         },
         "should respond with a free port (>= 32773)": function (err, port) {
           closeServers(); // close all the servers first!
@@ -75,7 +75,7 @@ vows.describe('portfinder').addBatch({
       "the getPort() method with stopPort smaller than available port": {
         topic: function () {
           // stopPort: 32722 is smaller than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32772 }, this.callback);
+          portfinder.getPort({ useRandom: true, stopPort: 32772 }, this.callback);
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
@@ -98,7 +98,7 @@ vows.describe('portfinder').addBatch({
       "the getPort() method with stopPort greater than available port": {
         topic: function () {
           // stopPort: 32774 is greater than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32780 }, this.callback);
+          portfinder.getPort({ useRandom: true, stopPort: 32780 }, this.callback);
         },
         "should respond with a free port less than provided stopPort": function(err, port) {
           closeServers() // close all the servers first!
@@ -119,7 +119,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method": {
         topic: function () {
-          portfinder.getPort(this.callback);
+          portfinder.getPort({useRandom: true}, this.callback);
         },
         "should respond with a free port (>= 32768)": function (err, port) {
           if (err) { debugVows(err); }
@@ -140,7 +140,7 @@ vows.describe('portfinder').addBatch({
         topic: function () {
          var _warn = console.warn
          console.warn = function(){console.warn.wasCalled = true; _warn()}
-          portfinder.getPort({port: 40001 }, this.callback);
+          portfinder.getPort({useRandom: true, port: 40001 }, this.callback);
         },
         "should log a warning and respond with a free port (> 40000)": function (err, port) {
           if (err) { debugVows(err); }
@@ -193,7 +193,7 @@ vows.describe('portfinder').addBatch({
     // regression test for indexzero/node-portfinder#65
     "the getPort() method with startPort less than or equal to 80": {
       topic: function () {
-        portfinder.getPort({startPort: 80}, this.callback);
+        portfinder.getPort({useRandom: true, startPort: 80}, this.callback);
       },
       "should not throw any error.": function(err, port) {
         if (err) { debugVows(err); }
@@ -209,7 +209,7 @@ vows.describe('portfinder').addBatch({
       },
       "the getPort() method requesting an unavailable port": {
         topic: function () {
-          portfinder.getPort({ port: 39998 }, this.callback);
+          portfinder.getPort({ useRandom: true, port: 39998 }, this.callback);
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!

--- a/test/port-finder-random-test.js
+++ b/test/port-finder-random-test.js
@@ -213,7 +213,6 @@ vows.describe('portfinder with useRandom').addBatch({
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
-          console.log({err, port})
 
           assert.isTrue(!!err);
           assert.equal(

--- a/test/port-finder-random-test.js
+++ b/test/port-finder-random-test.js
@@ -205,7 +205,7 @@ vows.describe('portfinder with useRandom').addBatch({
   "When using portfinder module": {
     "with no available ports above the start port": {
       topic: function () {
-        testHelper(servers, 39998, 40000, this.callback);
+        testHelper(servers, 39998, 40001, this.callback);
       },
       "the getPort() method requesting an unavailable port": {
         topic: function () {
@@ -213,6 +213,7 @@ vows.describe('portfinder with useRandom').addBatch({
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!
+          console.log({err, port})
 
           assert.isTrue(!!err);
           assert.equal(
@@ -224,6 +225,17 @@ vows.describe('portfinder with useRandom').addBatch({
       },
     }
   }
-})
-
-.export(module);
+}).addBatch({
+  "When using portfinder module": {
+    "the getPort() method with startPort equal to stopPort": {
+      topic: function () {
+        portfinder.getPort({port: 40000, useRandom: true}, this.callback);
+      },
+      "should return that port if it is available": function(err, port) {
+        if (err) { debugVows(err); }
+        assert.isTrue(!err);
+        assert.isTrue(port == 40000);
+      }
+    }
+  }
+}).export(module);

--- a/test/port-finder-sequential-test.js
+++ b/test/port-finder-sequential-test.js
@@ -1,0 +1,230 @@
+/*
+ * portfinder-test.js: Tests for the `portfinder` module.
+ *
+ * (C) 2011, Charlie Robbins
+ *
+ */
+
+"use strict";
+
+var vows = require('vows'),
+    assert = require('assert'),
+    portfinder = require('../lib/portfinder'),
+    testHelper = require('./helper'),
+    debug = require('debug');
+
+var debugVows = debug('portfinder:testVows');
+
+portfinder.basePort = 32768;
+
+var servers = [];
+
+var closeServers = function () {
+  servers.forEach(function (server) {
+    server.close();
+  });
+  servers = []
+}
+
+vows.describe('portfinder with sequential search (default)').addBatch({
+  "When using portfinder module": {
+    "with 5 existing servers": {
+      topic: function () {
+        testHelper(servers, this.callback);
+      },
+      "the getPort() method": {
+        topic: function () {
+          portfinder.getPort(this.callback);
+        },
+        "should respond with the first free port (32773)": function (err, port) {
+          closeServers(); // close all the servers first!
+
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.equal(port, 32773);
+        }
+      },
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with 5 existing servers": {
+      topic: function () {
+        testHelper(servers, this.callback);
+      },
+      "the getPort() method with user passed duplicate host": {
+        topic: function () {
+          portfinder.getPort({ host: 'localhost' }, this.callback);
+        },
+        "should respond with the first free port (32773)": function (err, port) {
+          closeServers(); // close all the servers first!
+
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.equal(port, 32773);
+        }
+      },
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with 5 existing servers": {
+      topic: function () {
+        testHelper(servers, this.callback);
+      },
+      "the getPort() method with stopPort smaller than available port": {
+        topic: function () {
+          // stopPort: 32722 is smaller than available port 32773 (32768 + 5)
+          portfinder.getPort({ stopPort: 32772 }, this.callback);
+        },
+        "should return error": function(err, port) {
+          closeServers() // close all the servers first!
+
+          assert.isTrue(!!err);
+          assert.equal(
+            err.message,
+            'No open ports found in between 32768 and 32772'
+          );
+          return;
+        }
+      },
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with 5 existing servers": {
+      topic: function () {
+        testHelper(servers, this.callback);
+      },
+      "the getPort() method with stopPort greater than available port": {
+        topic: function () {
+          // stopPort: 32774 is greater than available port 32773 (32768 + 5)
+          portfinder.getPort({ stopPort: 32774 }, this.callback);
+        },
+        "should respond with the first free port (32773) less than provided stopPort": function(err, port) {
+          closeServers() // close all the servers first!
+
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.equal(port, 32773);
+        }
+      },
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with no existing servers": {
+      topic: function () {
+        closeServers();
+        return null;
+      },
+      "the getPort() method": {
+        topic: function () {
+          portfinder.getPort(this.callback);
+        },
+        "should respond with the first free port (32768)": function (err, port) {
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.equal(port, 32768);
+        }
+      }
+    }
+  }
+}).addBatch({
+    "When using portfinder module": {
+      "with no existing servers": {
+        topic: function () {
+          closeServers();
+          return null;
+        },
+        "the getPort() method with a startPort above 40000 and no explicit stopPort": {
+          topic: function () {
+           var _warn = console.warn
+           console.warn = function(){console.warn.wasCalled = true; _warn()}
+            portfinder.getPort({ port: 40001 }, this.callback);
+          },
+          "should log a warning and respond with a free port (> 40000)": function (err, port) {
+            if (err) { debugVows(err); }
+            assert.isTrue(!err);
+            assert.isTrue(console.warn.wasCalled)
+            assert.isTrue(port > 40000);
+            assert.isTrue(port <= 65535);
+          }
+        }
+      }
+    }
+  }).addBatch({
+  "When using portfinder module": {
+    "with no existing servers": {
+      topic: function () {
+        closeServers();
+        return null;
+      },
+      "the getPortPromise() method": {
+        topic: function () {
+          var vow = this;
+
+          portfinder.getPortPromise()
+            .then(function (port) {
+              vow.callback(null, port);
+            })
+            .catch(function (err) {
+              vow.callback(err, null);
+            });
+        },
+        "should respond with a promise of first free port (32768) if Promise are available": function (err, port) {
+          if (typeof Promise !== 'function') {
+            assert.isTrue(!!err);
+            assert.equal(
+              err.message,
+              'Native promise support is not available in this version of node.' +
+              'Please install a polyfill and assign Promise to global.Promise before calling this method'
+            );
+            return;
+          }
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.equal(port, 32768);
+        }
+      },
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    // regression test for indexzero/node-portfinder#65
+    "the getPort() method with startPort less than or equal to 80": {
+      topic: function () {
+        portfinder.getPort({startPort: 80}, this.callback);
+      },
+      "should not throw any error.": function(err, port) {
+        if (err) { debugVows(err); }
+        assert.isTrue(!err);
+      }
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with no available ports above the start port": {
+      topic: function () {
+        testHelper(servers, 65530, 65536, this.callback);
+      },
+      "the getPort() method requesting an unavailable port": {
+        topic: function () {
+          portfinder.getPort({ port: 65530 }, this.callback);
+        },
+        "should return error": function(err, port) {
+          closeServers() // close all the servers first!
+
+          assert.isTrue(!!err);
+          assert.equal(
+            err.message,
+            'No open ports found in between 65530 and 65535'
+          );
+          return;
+        }
+      },
+    }
+  }
+})
+
+.export(module);

--- a/test/port-finder-sequential-test.js
+++ b/test/port-finder-sequential-test.js
@@ -225,6 +225,17 @@ vows.describe('portfinder with sequential search (default)').addBatch({
       },
     }
   }
-})
-
-.export(module);
+}).addBatch({
+  "When using portfinder module": {
+    "the getPort() method with startPort equal to stopPort": {
+      topic: function () {
+        portfinder.getPort({port: 40000}, this.callback);
+      },
+      "should return that port if it is available": function(err, port) {
+        if (err) { debugVows(err); }
+        assert.isTrue(!err);
+        assert.isTrue(port == 40000);
+      }
+    }
+  }
+}).export(module);

--- a/test/port-finder-sequential-test.js
+++ b/test/port-finder-sequential-test.js
@@ -101,7 +101,7 @@ vows.describe('portfinder with sequential search (default)').addBatch({
           // stopPort: 32774 is greater than available port 32773 (32768 + 5)
           portfinder.getPort({ stopPort: 32774 }, this.callback);
         },
-        "should respond with the first free port (32773) less than provided stopPort": function(err, port) {
+        "should respond with the first free port (32773) less than or equal to provided stopPort": function(err, port) {
           closeServers() // close all the servers first!
 
           if (err) { debugVows(err); }

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -72,10 +72,10 @@ vows.describe('portfinder').addBatch({
       topic: function () {
         testHelper(servers, this.callback);
       },
-      "the getPort() method with stopPort smaller than available port": { // HERE
+      "the getPort() method with stopPort smaller than available port": {
         topic: function () {
           // stopPort: 32722 is smaller than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32772 }, this.callback, true);
+          portfinder.getPort({ stopPort: 32772 }, this.callback);
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -72,10 +72,10 @@ vows.describe('portfinder').addBatch({
       topic: function () {
         testHelper(servers, this.callback);
       },
-      "the getPort() method with stopPort smaller than available port": {
+      "the getPort() method with stopPort smaller than available port": { // HERE
         topic: function () {
           // stopPort: 32722 is smaller than available port 32773 (32768 + 5)
-          portfinder.getPort({ stopPort: 32772 }, this.callback);
+          portfinder.getPort({ stopPort: 32772 }, this.callback, true);
         },
         "should return error": function(err, port) {
           closeServers() // close all the servers first!

--- a/test/port-finder-test.js
+++ b/test/port-finder-test.js
@@ -136,6 +136,29 @@ vows.describe('portfinder').addBatch({
         closeServers();
         return null;
       },
+      "the getPort() method with a startPort above 40000 and no explicit stopPort": {
+        topic: function () {
+         var _warn = console.warn
+         console.warn = function(){console.warn.wasCalled = true; _warn()}
+          portfinder.getPort({port: 40001 }, this.callback);
+        },
+        "should log a warning and respond with a free port (> 40000)": function (err, port) {
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.isTrue(console.warn.wasCalled)
+          assert.isTrue(port > 40000);
+          assert.isTrue(port <= 65535);
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using portfinder module": {
+    "with no existing servers": {
+      topic: function () {
+        closeServers();
+        return null;
+      },
       "the getPortPromise() method": {
         topic: function () {
           var vow = this;


### PR DESCRIPTION
This would fix the issue identified in https://github.com/http-party/node-portfinder/issues/85. If there is an existing consumer who uses `getPort` with a `startPort` greater than 40000, instead of throwing an Error this will log a warning to the console and bump the `stopPort` up to 65535 (i.e. behave the same as before `exports.highestPort` was reduced to 40000). 

An error is still thrown if the `stopPort` is lower than the `stopPort` when both of these values are below 40000.