### PR TITLE
Add missing highestPort property to TypeScript definition

### DIFF
--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -34,6 +34,11 @@ interface PortFinderOptions{
 export let basePort: number;
 
 /**
+ * The highest port to end any port search from.
+ */
+export let highestPort: number;
+
+/**
  * Responds with a unbound port on the current machine.
  */
 export function getPort(callback: PortfinderCallback): void;


### PR DESCRIPTION
Was causing warning about missing property.

#### Before:

![before](https://user-images.githubusercontent.com/2285372/81962576-d58fd000-960b-11ea-8f7e-74a511b35c58.png)

#### After:

![after](https://user-images.githubusercontent.com/2285372/81962580-d6c0fd00-960b-11ea-9f6b-4253be6e8c40.png)


Signed-off-by: Bruno Gaspar <brunofgaspar1@gmail.com>