### PR TITLE
Wait until server is closed before invoking callback.

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -38,9 +38,11 @@ internals.testPort = function(options, callback) {
   function onListen () {
     debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
 
-        options.server.removeListener('error', onError);
-        options.server.close();
+    options.server.removeListener('error', onError);
+    options.server.close(function () {
+      debugTestPort("done w/ testPort(): Server closed", options.host, "port", options.port);
       callback(null, options.port);
+    });
   }
 
   function onError (err) {


### PR DESCRIPTION
Otherwise the port may be blocked because it is signaled to be
free while server was not yet closed.

See bug #104