### PR TITLE
Fix #108 - Bumping up mkdirp version to 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "^2.6.2",
     "debug": "^3.1.1",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.5"
   },
   "devDependencies": {
     "glob": "^7.1.4",


### PR DESCRIPTION
Hi!

I see that in PR #101 you bumped-up the version of `mkdirp` to 0.5.5 which in turn updates `minimist` to 1.2.5
which addresses https://www.npmjs.com/advisories/1179

Problem is that this PR only updated `package-lock.json` and not `package.json` that remains at 0.5.1. As `package.json` still depends on `mkdirp` 0.5.1, when we get `node-portfinder` as a dependency, we still get an old version of `minimist`.