### PR TITLE
Add mutator methods to allow ports ranges to be set with module-style imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ By default `portfinder` will start searching from `8000` and scan until maximum 
 You can change this globally by setting:
 
 ```js
-portfinder.basePort = 3000;    // default: 8000
-portfinder.highestPort = 3333; // default: 65535
+portfinder.setBasePort(3000);    // default: 8000
+portfinder.setHighestPort(3333); // default: 65535
 ```
 
 or by passing optional options object on each invocation:

--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -34,9 +34,19 @@ interface PortFinderOptions{
 export let basePort: number;
 
 /**
+ * Set the lowest port to begin any port search from.
+ */
+export setBasePort(port: number);
+
+/**
  * The highest port to end any port search from.
  */
 export let highestPort: number;
+
+/**
+ * Set the higheset port to end any port search from.
+ */
+export setHighestPort(port: number);
 
 /**
  * Responds with a unbound port on the current machine.

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -87,10 +87,26 @@ internals.testPort = function(options, callback) {
 exports.basePort = 8000;
 
 //
+// ### function setBasePort (port)
+// #### @port {Number} The new base port
+//
+exports.setBasePort = function (port) {
+  exports.basePort = port;
+}
+
+//
 // ### @highestPort {Number}
 // Largest port number is an unsigned short 2**16 -1=65335
 //
 exports.highestPort = 65535;
+
+//
+// ### function setHighestPort (port)
+// #### @port {Number} The new highest port
+//
+exports.setHighestPort = function (port) {
+  exports.highestPort = port;
+}
 
 //
 // ### @basePath {string}


### PR DESCRIPTION
Ran into a compiler error when using portfinder in TypeScript. Module exports are considered immutable in typescript, so the following code won't compile:

```
import * as portfinder from "portfinder";

portfinder.basePort = 3000;
```

Instead, a new accessor method allows us to say `portfinder.setBasePort(3000);`