### PR TITLE
Only import the needed functions from async

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -11,9 +11,11 @@ var fs = require('fs'),
     os = require('os'),
     net = require('net'),
     path = require('path'),
-    _async = require('async'),
     debug = require('debug'),
     mkdirp = require('mkdirp').mkdirp;
+
+var eachSeries = require('async/eachSeries');
+var timesSeries = require('async/timesSeries');
 
 var debugTestPort = debug('portfinder:testPort'),
     debugGetPort = debug('portfinder:getPort'),
@@ -142,7 +144,7 @@ exports.getPort = function (options, callback) {
   }
 
   var openPorts = [], currentHost;
-  return _async.eachSeries(exports._defaultHosts, function(host, next) {
+  return eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);
 
     return internals.testPort({ host: host, port: options.port }, function(err, port) {
@@ -244,7 +246,7 @@ exports.getPorts = function (count, options, callback) {
   }
 
   var lastPort = null;
-  _async.timesSeries(count, function(index, asyncCallback) {
+  timesSeries(count, function(index, asyncCallback) {
     if (lastPort) {
       options.port = exports.nextPort(lastPort);
     }


### PR DESCRIPTION
This reduces the size of portfinder from 34 KB to 14 KB