### PR TITLE
refactor: using indexOf to check unique host

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -126,19 +126,9 @@ exports.getPort = function (options, callback) {
   }
 
   if (options.host) {
-
-    var hasUserGivenHost;
-    for (var i = 0; i < exports._defaultHosts.length; i++) {
-      if (exports._defaultHosts[i] === options.host) {
-        hasUserGivenHost = true;
-        break;
-      }
+    if (exports._defaultHosts.indexOf(options.host) !== -1) {
+      exports._defaultHosts.push(options.host)
     }
-
-    if (!hasUserGivenHost) {
-      exports._defaultHosts.push(options.host);
-    }
-
   }
 
   var openPorts = [], currentHost;


### PR DESCRIPTION
Hi,

I was reading the source code for personal interest and found that you are using a loop to check if the host is unique. I think indexOf() could be much faster than the loop. Here is the comparison on my laptop:

loop: 4.363ms
indexOf: 0.005ms