### PR TITLE
Bump version of async in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lib"
   ],
   "dependencies": {
-    "async": "^2.6.2",
+    "async": "^2.6.4",
     "debug": "^3.1.1",
     "mkdirp": "^0.5.5"
   },


### PR DESCRIPTION
PR bumps the version of `async` dependency in package.json so that it's not possible to get a vulnerable version of `async` via this dependency. #130 only bumped the version in the `package-lock.json` file which only affects this repository, and not downstream consumers.