### PR TITLE
Add test around recursively making socket directory

### DIFF
--- a/test/port-finder-socket-test.js
+++ b/test/port-finder-socket-test.js
@@ -69,7 +69,15 @@ function stopServers(callback, index) {
 }
 
 function cleanup(callback) {
-  fs.rmdirSync(badDir);
+  if (fs.existsSync(path.join(badDir, 'deeply', 'nested'))) {
+    fs.rmdirSync(path.join(badDir, 'deeply', 'nested'));
+  }
+  if (fs.existsSync(path.join(badDir, 'deeply'))) {
+    fs.rmdirSync(path.join(badDir, 'deeply'));
+  }
+  if (fs.existsSync(badDir)) {
+    fs.rmdirSync(badDir);
+  }
   stopServers(callback, 0);
 }
 
@@ -83,7 +91,7 @@ vows.describe('portfinder').addBatch({
           }, this.callback);
         }.bind(this));
       },
-      "the getPort() method": {
+      "the getSocket() method": {
         topic: function () {
           portfinder.getSocket({
             path: path.join(socketDir, 'test.sock')
@@ -100,7 +108,7 @@ vows.describe('portfinder').addBatch({
   "When using portfinder module": {
     "with no existing servers": {
       "the getSocket() method": {
-        "with a directory that doesnt exist": {
+        "with a directory that doesn't exist": {
           topic: function () {
             fs.rmdir(badDir, function () {
               portfinder.getSocket({
@@ -111,6 +119,24 @@ vows.describe('portfinder').addBatch({
           "should respond with the first free socket (test.sock)": function (err, socket) {
             assert.isTrue(!err);
             assert.equal(socket, path.join(badDir, 'test.sock'));
+          }
+        },
+        "with a nested directory that doesn't exist": {
+          topic: function () {
+            var that = this;
+            fs.rmdir(path.join(badDir, 'deeply', 'nested'), function () {
+              fs.rmdir(path.join(badDir, 'deeply'), function () {
+                fs.rmdir(badDir, function () {
+                  portfinder.getSocket({
+                    path: path.join(badDir, 'deeply', 'nested', 'test.sock')
+                  }, that.callback);
+                });
+              });
+            });
+          },
+          "should respond with the first free socket (test.sock)": function (err, socket) {
+            assert.isTrue(!err);
+            assert.equal(socket, path.join(badDir, 'deeply', 'nested', 'test.sock'));
           }
         },
         "with a directory that exists": {


### PR DESCRIPTION
PR adds a test case that validates the recursive mkdir behavior that currently exists within the `getSocket` function. This helps demonstrate the breaking change in #134 which removes `mkdirp` in favor of the builtin `fs.mkdir` where for node < 10.12, the `recursive` flag didn't exist, and so it would not behave the same as `mkdirp`. To demonstrate that, I merged this code onto the `modernize` branch in my fork to trigger CI, and where all node < 10.x fail: https://github.com/MasterOdin/node-portfinder/actions/runs/2782492617.