### PR TITLE
Remove unused test imports

### DIFF
--- a/test/port-finder-socket-test.js
+++ b/test/port-finder-socket-test.js
@@ -8,14 +8,12 @@
 "use strict";
 
 var assert = require('assert'),
-    exec = require('child_process').exec,
     net = require('net'),
     path = require('path'),
     _async = require('async'),
     vows = require('vows'),
     portfinder = require('../lib/portfinder'),
-    fs = require('fs'),
-    glob = require('glob');
+    fs = require('fs');
 
 var servers = [],
     socketDir = path.join(__dirname, 'fixtures'),


### PR DESCRIPTION
`exec` or `glob` were not being used in this test file, and so I've removed the import of them. This looks to be the only file that had unused imports.