### PR TITLE
Test TS types in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     strategy:
       fail-fast: false
       matrix:
@@ -33,3 +33,21 @@ jobs:
       run: set DEBUG=*
 
     - run: npm test
+
+  test-types:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Install typescript
+      run: npm install --save-dev typescript
+
+    - run: node_modules/.bin/tsc lib/portfinder.d.ts


### PR DESCRIPTION
This PR modifies the current CI so that it runs the typescript compiler over the `portfinder.d.ts` file to minimally check that it's valid TS. A potential further step would be to use something like [tsd](https://www.npmjs.com/package/tsd) to write unit tests on the types, but the types here are relatively simple that I'm not sure how much benefit that'd bring.

This PR will currently fail the new CI step ([test run](https://github.com/http-party/node-portfinder/runs/7727997530?check_suite_focus=true)) until #139 is merged. Once #139 is merged, I'll rebase `master` onto this branch and it should then now pass.

Also, this PR only makes sense if #140 were to be rejected.