### PR TITLE
Add TS return signature to setPort functions

### DIFF
--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -36,7 +36,7 @@ export let basePort: number;
 /**
  * Set the lowest port to begin any port search from.
  */
-export function setBasePort(port: number);
+export function setBasePort(port: number): void;
 
 /**
  * The highest port to end any port search from.
@@ -46,7 +46,7 @@ export let highestPort: number;
 /**
  * Set the higheset port to end any port search from.
  */
-export function setHighestPort(port: number);
+export function setHighestPort(port: number): void;
 
 /**
  * Responds with a unbound port on the current machine.


### PR DESCRIPTION
PR adds a return signature of `void` to the `setBasePort` and `setHighestPort` functions added in #115. Without these, TS will implicitly type them as a `any`, which then allows someone to do anything with the "return value" in TS, losing some of the protections TS gives.

Sorry @eriktrom that I didn't catch this while I put together #141 and was looking at this function and so could have gone in 1.0.30 release.