### PR TITLE
Add strict flag to CI TS typechecking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
     - name: Install typescript
       run: npm install --save-dev typescript
 
-    - run: node_modules/.bin/tsc lib/portfinder.d.ts
+    - run: node_modules/.bin/tsc --strict lib/portfinder.d.ts


### PR DESCRIPTION
PR adds the `--strict` flag to the tsc typechecking that the CI was doing. This increases the strength of typechecking (see https://www.typescriptlang.org/tsconfig#strict for full details), but for this particular case, it's mostly just for catching no implicit any usage. An alternative would be to use `--noImplicitAny` flag instead, but it doesn't hurt to have tsc validate the definition file is as strict as possible even if some of the stuff doesn't really apply.

Note, this PR will fail until #143 is merged.