### PR TITLE
Add promise version of getPorts function

### DIFF
--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -54,9 +54,18 @@ export function setHighestPort(port: number): void;
 export function getPort(callback: PortfinderCallback): void;
 export function getPort(options: PortFinderOptions, callback: PortfinderCallback): void;
 
-export function getPorts(count: number, options: PortFinderOptions, callback: (err: Error, ports: Array<number>) => void): void;
-
 /**
  * Responds a promise of an unbound port on the current machine.
  */
 export function getPortPromise(options?: PortFinderOptions): Promise<number>;
+
+/**
+ * Responds with an array of unbound ports on the current machine.
+ */
+export function getPorts(count: number, callback: (err: Error, ports: Array<number>) => void): void;
+export function getPorts(count: number, options: PortFinderOptions, callback: (err: Error, ports: Array<number>) => void): void;
+
+/**
+ * Responds a promise that resolves to an array of unbound ports on the current machine.
+ */
+export function getPortsPromise(count: number, options?: PortFinderOptions): Promise<Array<number>>;

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -267,6 +267,30 @@ exports.getPorts = function (count, options, callback) {
 };
 
 //
+// ### function getPortPromise (options)
+// #### @count {Number} The number of ports to find
+// #### @options {Object} Settings to use when finding the necessary port
+// Responds with a promise that resolves to an array of unbound ports on the current machine.
+//
+exports.getPortsPromise = function (count, options) {
+  if (typeof Promise !== 'function') {
+    throw Error('Native promise support is not available in this version of node.' +
+      'Please install a polyfill and assign Promise to global.Promise before calling this method');
+  }
+  if (!options) {
+    options = {};
+  }
+  return new Promise(function(resolve, reject) {
+    exports.getPorts(count, options, function(err, ports) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(ports);
+    });
+  });
+}
+
+//
 // ### function getSocket (options, callback)
 // #### @options {Object} Settings to use when finding the necessary port
 // #### @callback {function} Continuation to respond to when complete.

--- a/test/port-finder-multiple-test.js
+++ b/test/port-finder-multiple-test.js
@@ -59,4 +59,40 @@ vows.describe('portfinder').addBatch({
       }
     }
   }
+}).addBatch({
+  "When using portfinder module": {
+    "with no existing servers": {
+      topic: function () {
+        closeServers();
+        return null;
+      },
+      "the getPortPromises() method with an argument of 3": {
+        topic: function () {
+          var vow = this;
+
+          portfinder.getPortsPromise(3)
+            .then(function (ports) {
+              vow.callback(null, ports);
+            })
+            .catch(function (err) {
+              vow.callback(err, null);
+            });
+        },
+        "should respond with the first three available ports (32768, 32769, 32770) if Promise are available": function (err, ports) {
+          if (typeof Promise !== 'function') {
+            assert.isTrue(!!err);
+            assert.equal(
+              err.message,
+              'Native promise support is not available in this version of node.' +
+              'Please install a polyfill and assign Promise to global.Promise before calling this method'
+            );
+            return;
+          }
+          if (err) { debugVows(err); }
+          assert.isTrue(!err);
+          assert.deepEqual(ports, [32768, 32769, 32770]);
+        }
+      },
+    }
+  }
 }).export(module);


### PR DESCRIPTION
PR adds a new `getPortsPromise` function to allow using a promisified version of `getPorts`, similar to how there's a `getPortPromise` version of `getPort`. A test is included for the function, which mimics what I saw for testing `getPortPromise`.

I also fixed a type error which made it seem like the `options` parameter was required for `getPorts`, where it's optional, just need to always pass the `count` and `callback`. 