### PR TITLE
Fix adding options.host to defaultHosts list

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -141,10 +141,8 @@ exports.getPort = function (options, callback) {
     }
   }
 
-  if (options.host) {
-    if (exports._defaultHosts.indexOf(options.host) !== -1) {
-      exports._defaultHosts.push(options.host)
-    }
+  if (options.host && exports._defaultHosts.indexOf(options.host) === -1) {
+    exports._defaultHosts.push(options.host)
   }
 
   var openPorts = [], currentHost;


### PR DESCRIPTION
PR fixes a bug reported in https://github.com/http-party/node-portfinder/pull/120#issuecomment-1502633024, where the current `indexOf` check will only succeed if `options.host` was already in `exports._defaultHosts`, as opposed to the desired behavior of appending it if it's _not_ in the array.

I've also cleaned up the nested conditional to just be one level as the nesting was not necessary.