### PR TITLE
Wait until server is closed before invoking callback

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -39,8 +39,10 @@ internals.testPort = function(options, callback) {
     debugTestPort("done w/ testPort(): OK", options.host, "port", options.port);
 
     options.server.removeListener('error', onError);
-    options.server.close();
-    callback(null, options.port);
+    options.server.close(function () {
+      debugTestPort("done w/ testPort(): Server closed", options.host, "port", options.port);
+      callback(null, options.port);
+    });
   }
 
   function onError (err) {


### PR DESCRIPTION
With the current implementation, there is a chance that a user binds a socket on a port (that was reported as being available) although the server (created to check whether that port is available) is not fully closed yet. This causes the binding to fail, because the port is still in use.

In this PR, we change the implementation such that the the callback passed to the `testPort` is invoked when the server is fully closed. Thanks to @sla89 for the idea!

Unfortunately, we didn't manage to write a unit tests that reliably verifies the correct behavior. I'm open for ideas ;)