### PR TITLE
Update .github/workflows/ci.yml to exclude macOS for old versions of node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ jobs:
       matrix:
         node-version: [0.12.x, 4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            node-version: 0.12.x
+          - os: macos-latest
+            node-version: 4.x
+          - os: macos-latest
+            node-version: 6.x
+          - os: macos-latest
+            node-version: 8.x
+          - os: macos-latest
+            node-version: 10.x
+          - os: macos-latest
+            node-version: 12.x
+          - os: macos-latest
+            node-version: 14.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Exclude macos-latest, node-version 0.12.x, 4.x, 6.x, 8.x, 10.x, 12.x, 14.x from running on CI to prevent the failure:

`Unable to find Node version 'y.x' for platform darwin and architecture arm64.`