### PR TITLE
Update async to ^3.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.33",
       "license": "MIT",
       "dependencies": {
-        "async": "^2.6.4",
+        "async": "^3.2.6",
         "debug": "^3.2.7",
         "mkdirp": "^0.5.6"
       },
@@ -916,12 +916,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -4171,7 +4168,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -7439,12 +7437,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "async-function": {
       "version": "1.0.0",
@@ -9928,7 +9923,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lib"
   ],
   "dependencies": {
-    "async": "^2.6.4",
+    "async": "^3.2.6",
     "debug": "^3.2.7",
     "mkdirp": "^0.5.6"
   },

--- a/test/helper.js
+++ b/test/helper.js
@@ -31,18 +31,20 @@ module.exports.startServers = function(servers, startPort, endPort, callback) {
   endPort = endPort || 32773;
 
   _async.whilst(
-    function () { return base < endPort; },
+    function (cb) { cb(null, base < endPort); },
     function (next) {
       var hosts = ['localhost'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;
-    }, callback);
+    },
+    callback,
+  );
 };
 
 module.exports.stopServers = function(servers, callback) {
   _async.whilst(
-    function() { return servers.length > 0; },
+    function(cb) { cb(null, servers.length > 0); },
     function(next) {
       servers.pop().close(next);
     },

--- a/test/port-finder-socket.test.js
+++ b/test/port-finder-socket.test.js
@@ -21,7 +21,7 @@ function createServers (callback) {
   var base = 0;
 
   _async.whilst(
-    function () { return base < 5 },
+    function (cb) { cb(null, base < 5); },
     function (next) {
       var server = net.createServer(function () { }),
           name = base === 0 ? 'test.sock' : 'test' + base + '.sock',


### PR DESCRIPTION
Closes #153 

PR updates async dependency to latest version. The only change that really affects this library was that the first function argument to [`whilst`](https://caolan.github.io/async/v3/docs.html#whilst) now has a callback function that need to call to return the test result, vs just returning it as before with v2.

Per the discussion in the linked issue, need to drop support for Node <= 4 as async dropped support for those versions of node.