### PR TITLE
Remove check for promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `portfinder` module has a simple interface:
   });
 ```
 
-Or with promise (if `Promise`s are supported) :
+Or using promises:
 
 ``` js
   const portfinder = require('portfinder');
@@ -38,8 +38,6 @@ Or with promise (if `Promise`s are supported) :
         //
     });
 ```
-
-If `portfinder.getPortPromise()` is called on a Node version without Promise (<4), it will throw an Error unless [Bluebird](http://bluebirdjs.com/docs/getting-started.html) or any Promise pollyfill is used.
 
 ### Ports search scope
 

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -226,10 +226,6 @@ exports.getPort = function (options, callback) {
 // Responds a promise to an unbound port on the current machine.
 //
 exports.getPortPromise = function (options) {
-  if (typeof Promise !== 'function') {
-    throw Error('Native promise support is not available in this version of node.' +
-      'Please install a polyfill and assign Promise to global.Promise before calling this method');
-  }
   if (!options) {
     options = {};
   }
@@ -280,10 +276,6 @@ exports.getPorts = function (count, options, callback) {
 // Responds with a promise that resolves to an array of unbound ports on the current machine.
 //
 exports.getPortsPromise = function (count, options) {
-  if (typeof Promise !== 'function') {
-    throw Error('Native promise support is not available in this version of node.' +
-      'Please install a polyfill and assign Promise to global.Promise before calling this method');
-  }
   if (!options) {
     options = {};
   }


### PR DESCRIPTION
PR drops the code checks for promise support as support for promises was added in node 4.