### PR TITLE
Replace var with const/let

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -7,19 +7,19 @@
 
 "use strict";
 
-var fs = require('fs'),
-    os = require('os'),
-    net = require('net'),
-    path = require('path'),
-    _async = require('async'),
-    debug = require('debug'),
-    mkdirp = require('mkdirp').mkdirp;
+const fs = require('fs'),
+      os = require('os'),
+      net = require('net'),
+      path = require('path'),
+      _async = require('async'),
+      debug = require('debug'),
+      mkdirp = require('mkdirp').mkdirp;
 
-var debugTestPort = debug('portfinder:testPort'),
-    debugGetPort = debug('portfinder:getPort'),
-    debugDefaultHosts = debug('portfinder:defaultHosts');
+const debugTestPort = debug('portfinder:testPort'),
+      debugGetPort = debug('portfinder:getPort'),
+      debugDefaultHosts = debug('portfinder:defaultHosts');
 
-var internals = {};
+const internals = {};
 
 internals.testPort = function(options, callback) {
   if (!callback) {
@@ -54,7 +54,7 @@ internals.testPort = function(options, callback) {
       return callback(err);
     }
 
-    var nextPort = exports.nextPort(options.port);
+    const nextPort = exports.nextPort(options.port);
 
     if (nextPort > exports.highestPort) {
       return callback(new Error('No open ports available'));
@@ -154,7 +154,8 @@ exports.getPort = function (options, callback) {
     exports._defaultHosts.push(options.host)
   }
 
-  var openPorts = [], currentHost;
+  const openPorts = [];
+  let currentHost;
   return _async.eachSeries(exports._defaultHosts, function(host, next) {
     debugGetPort("in eachSeries() iteration callback: host is", host);
 
@@ -183,10 +184,10 @@ exports.getPort = function (options, callback) {
           // NOTE: We may need to one day handle `my-non-existent-host.local` if users
           // report frustration with passing in hostnames that DONT map to bindable
           // hosts, without showing them a good error.
-          var msg = 'Provided host ' + options.host + ' could NOT be bound. Please provide a different host address or hostname';
+          const msg = 'Provided host ' + options.host + ' could NOT be bound. Please provide a different host address or hostname';
           return callback(Error(msg));
         } else {
-          var idx = exports._defaultHosts.indexOf(currentHost);
+          const idx = exports._defaultHosts.indexOf(currentHost);
           exports._defaultHosts.splice(idx, 1);
           return exports.getPort(options, callback);
         }
@@ -209,7 +210,7 @@ exports.getPort = function (options, callback) {
         return callback(null, openPorts[0]);
       }
       else {
-        var msg = 'No open ports found in between '+ options.startPort + ' and ' + options.stopPort;
+        const msg = 'No open ports found in between '+ options.startPort + ' and ' + options.stopPort;
         return callback(Error(msg));
       }
     } else {
@@ -256,7 +257,7 @@ exports.getPorts = function (count, options, callback) {
     options = {};
   }
 
-  var lastPort = null;
+  let lastPort = null;
   _async.timesSeries(count, function(index, asyncCallback) {
     if (lastPort) {
       options.port = exports.nextPort(lastPort);
@@ -363,7 +364,7 @@ exports.getSocket = function (options, callback) {
   // then test connection.
   //
   function checkAndTestSocket () {
-    var dir = path.dirname(options.path);
+    const dir = path.dirname(options.path);
 
     fs.stat(dir, function (err, stats) {
       if (err || !stats.isDirectory()) {
@@ -402,11 +403,11 @@ exports.nextPort = function (port) {
 // specified `socketPath`.
 //
 exports.nextSocket = function (socketPath) {
-  var dir = path.dirname(socketPath),
-      name = path.basename(socketPath, '.sock'),
-      match = name.match(/^([a-zA-z]+)(\d*)$/i),
-      index = parseInt(match[2]),
-      base = match[1];
+  const dir = path.dirname(socketPath),
+        name = path.basename(socketPath, '.sock'),
+        match = name.match(/^([a-zA-z]+)(\d*)$/i),
+        base = match[1];
+  let index = parseInt(match[2]);
   if (isNaN(index)) {
     index = 0;
   }
@@ -492,7 +493,7 @@ exports.nextSocket = function (socketPath) {
  *     Note we export this so we can use it in our tests, otherwise this API is private
  */
 exports._defaultHosts = (function() {
-  var interfaces = {};
+  let interfaces = {};
   try{
     interfaces = os.networkInterfaces();
   }
@@ -514,13 +515,13 @@ exports._defaultHosts = (function() {
     }
   }
 
-  var interfaceNames = Object.keys(interfaces),
-      hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
-      results = [hiddenButImportantHost];
-  for (var i = 0; i < interfaceNames.length; i++) {
-    var _interface = interfaces[interfaceNames[i]];
-    for (var j = 0; j < _interface.length; j++) {
-      var curr = _interface[j];
+  const interfaceNames = Object.keys(interfaces),
+        hiddenButImportantHost = '0.0.0.0', // !important - dont remove, hence the naming :)
+        results = [hiddenButImportantHost];
+  for (let i = 0; i < interfaceNames.length; i++) {
+    const _interface = interfaces[interfaceNames[i]];
+    for (let j = 0; j < _interface.length; j++) {
+      const curr = _interface[j];
       results.push(curr.address);
     }
   }

--- a/test/getPort.js
+++ b/test/getPort.js
@@ -1,15 +1,16 @@
-var portfinder = require('../lib/portfinder');
+const portfinder = require('../lib/portfinder');
 
-if(process.argv[2]) {
-  var port = process.argv[2];
-  if ( isNaN(port) ) {
+if (process.argv[2]) {
+  const port = process.argv[2];
+  if (isNaN(port)) {
     console.log('passed value is not a port');
   } else {
     portfinder.basePort = port;
   }
 }
+
 portfinder.getPort(function(err, port) {
-  if(err) {
+  if (err) {
     console.error(err);
   } else {
     console.log(port);

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var _async = require('async'),
-    http = require('http');
+const _async = require('async'),
+      http = require('http');
 
 
 function createServer(base, host, next) {
-  var server = http.createServer(function () {});
+  const server = http.createServer(function () {});
 
   if (!next) {
     server.listen(base, host);
@@ -27,13 +27,13 @@ module.exports.startServers = function(servers, startPort, endPort, callback) {
     startPort = undefined;
   }
 
-  var base = startPort || 32768;
+  let base = startPort || 32768;
   endPort = endPort || 32773;
 
   _async.whilst(
     function () { return base < endPort; },
     function (next) {
-      var hosts = ['localhost'];
+      const hosts = ['localhost'];
       while (hosts.length > 1) { servers.push(createServer(base, hosts.shift())); }
       servers.push(createServer(base, hosts.shift(), next)); // call next for host
       base++;

--- a/test/port-finder-integration.test.js
+++ b/test/port-finder-integration.test.js
@@ -5,13 +5,13 @@
  */
 
 
-var portfinder = require('../lib/portfinder'),
-    child_process = require('child_process'),
-    path = require('path'),
-    http = require('http');
+const portfinder = require('../lib/portfinder'),
+      child_process = require('child_process'),
+      path = require('path'),
+      http = require('http');
 
 const host = "localhost";
-var server;
+let server;
 
 describe('portfinder', function () {
   afterAll(function (done) {
@@ -24,14 +24,14 @@ describe('portfinder', function () {
     portfinder.getPort(function (err, port) {
       expect(err).toBeNull();
       server = http.createServer(function () {}).listen(port, host, function () {
-        var timeout = false;
-        var fileToExec = path.join(__dirname, 'getPort.js');
-        var timer = setTimeout(function () {
+        let timeout = false;
+        const fileToExec = path.join(__dirname, 'getPort.js');
+        const timer = setTimeout(function () {
           timeout = true;
           process.kill(child.pid);
           done("timeout");
         }, 10000); // 10 seconds
-        var child = child_process.spawn('node', [fileToExec, port]);
+        const child = child_process.spawn('node', [fileToExec, port]);
         child.on('close', function () {
           if (timeout === false) {
             clearTimeout(timer);

--- a/test/port-finder-multiple.test.js
+++ b/test/port-finder-multiple.test.js
@@ -7,13 +7,13 @@
 
 "use strict";
 
-var portfinder = require('../lib/portfinder'),
-    helper = require('./helper');
+const portfinder = require('../lib/portfinder'),
+      helper = require('./helper');
 
 portfinder.basePort = 32768;
 
 describe('with 5 existing servers', function () {
-  var servers = [];
+  const servers = [];
   beforeAll(function (done) {
     helper.startServers(servers, done);
   });

--- a/test/port-finder-socket.test.js
+++ b/test/port-finder-socket.test.js
@@ -7,25 +7,25 @@
 
 "use strict";
 
-var net = require('net'),
-    path = require('path'),
-    _async = require('async'),
-    portfinder = require('../lib/portfinder'),
-    fs = require('fs');
+const net = require('net'),
+      path = require('path'),
+      _async = require('async'),
+      portfinder = require('../lib/portfinder'),
+      fs = require('fs');
 
-var servers = [],
-    socketDir = path.join(__dirname, 'fixtures'),
-    badDir = path.join(__dirname, 'bad-dir');
+const servers = [],
+      socketDir = path.join(__dirname, 'fixtures'),
+      badDir = path.join(__dirname, 'bad-dir');
 
 function createServers (callback) {
-  var base = 0;
+  let base = 0;
 
   _async.whilst(
     function () { return base < 5 },
     function (next) {
-      var server = net.createServer(function () { }),
-          name = base === 0 ? 'test.sock' : 'test' + base + '.sock',
-          sock = path.join(socketDir, name);
+      const server = net.createServer(function () { }),
+            name = base === 0 ? 'test.sock' : 'test' + base + '.sock';
+      let sock = path.join(socketDir, name);
 
       // shamelessly stolen from foreverjs,
       // https://github.com/foreverjs/forever/blob/6d143609dd3712a1cf1bc515d24ac6b9d32b2588/lib/forever/worker.js#L141-L154

--- a/test/port-finder.test.js
+++ b/test/port-finder.test.js
@@ -7,13 +7,13 @@
 
 "use strict";
 
-var portfinder = require('../lib/portfinder'),
-    helper = require('./helper');
+const portfinder = require('../lib/portfinder'),
+      helper = require('./helper');
 
 portfinder.basePort = 32768;
 
 describe('with 5 existing servers', function () {
-  var servers = [];
+  const servers = [];
   beforeAll(function (done) {
     helper.startServers(servers, done);
   });
@@ -97,7 +97,7 @@ test('the getPort() method with startPort less than or equal to 80', function (d
 });
 
 describe('with no available ports above the start port', function () {
-  var servers = [];
+  const servers = [];
   beforeEach(function (done) {
     helper.startServers(servers, 65530, 65536, done);
   });


### PR DESCRIPTION
PR replaces usage of `var` with `const`/`let` which were introduced in Node 6. I didn't touch the `var` in the README as that was done in #154.