### PR TITLE
Remove mkdirp dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-latest
-            node-version: 6.x
-          - os: macos-latest
-            node-version: 8.x
           - os: macos-latest
             node-version: 10.x
           - os: macos-latest

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -12,8 +12,7 @@ const fs = require('fs'),
       net = require('net'),
       path = require('path'),
       _async = require('async'),
-      debug = require('debug'),
-      mkdirp = require('mkdirp').mkdirp;
+      debug = require('debug');
 
 const debugTestPort = debug('portfinder:testPort'),
       debugGetPort = debug('portfinder:getPort'),
@@ -339,7 +338,7 @@ exports.getSocket = function (options, callback) {
   // against the socket.
   //
   function createAndTestSocket (dir) {
-    mkdirp(dir, options.mod, function (err) {
+    fs.mkdir(dir, { mode: options.mod, recursive: true }, function (err) {
       if (err) {
         return callback(err);
       }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   ],
   "dependencies": {
     "async": "^3.2.6",
-    "debug": "^4.3.6",
-    "mkdirp": "^0.5.6"
+    "debug": "^4.3.6"
   },
   "devDependencies": {
     "jest": "^24.9.0"
@@ -29,7 +28,7 @@
     "test": "jest --runInBand"
   },
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 10.12"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Closes #163 

PR removes the `mkdirp` dependency relying on `{ recursive: true }` for `fs.mkdir` which has the same behavior. This necessitated bumping the supported node version to 10.12 as that's the version of Node that added this feature.

Note, I did not remove the recursive folder removal in the socket test (https://github.com/node-portfinder/node-portfinder/blob/b64ab4f707fccc079da3f86716ec0c78be61a30b/test/port-finder-socket.test.js#L68-L76) as `recursive` was added to [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) in 12.10, and then they deprecated that option and added the [`fs.rm`](https://nodejs.org/api/fs.html#fsrmpath-options-callback) function in 14.14.