### PR TITLE
getPort/getPorts return promise if no callback

### DIFF
--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -61,6 +61,7 @@ export function setBasePath(path: string): void;
 /**
  * Responds with a unbound port on the current machine.
  */
+export function getPort(options: PortFinderOptions): Promise<number>;
 export function getPort(callback: PortfinderCallback): void;
 export function getPort(options: PortFinderOptions, callback: PortfinderCallback): void;
 
@@ -72,6 +73,7 @@ export function getPortPromise(options?: PortFinderOptions): Promise<number>;
 /**
  * Responds with an array of unbound ports on the current machine.
  */
+export function getPorts(count: number, options: PortFinderOptions): Promise<Array<number>>;
 export function getPorts(count: number, callback: (err: Error, ports: Array<number>) => void): void;
 export function getPorts(count: number, options: PortFinderOptions, callback: (err: Error, ports: Array<number>) => void): void;
 

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -121,18 +121,12 @@ exports.basePath = '/tmp/portfinder'
 //
 exports.setBasePath = function (path) {
   exports.basePath = path;
-}
+};
 
-// ### function getPort (options, callback)
-// #### @options {Object} Settings to use when finding the necessary port
-// #### @callback {function} Continuation to respond to when complete.
-// Responds with a unbound port on the current machine.
-//
-exports.getPort = function (options, callback) {
+internals.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
     options = {};
-
   }
 
   options.port   = Number(options.port) || Number(exports.basePort);
@@ -220,33 +214,39 @@ exports.getPort = function (options, callback) {
   });
 };
 
+// ### function getPort (options, callback)
+// #### @options {Object} Settings to use when finding the necessary port
+// #### @callback {function} Continuation to respond to when complete.
+// Responds with a unbound port on the current machine.
+//
+exports.getPort = function (options, callback) {
+  if (!callback) {
+    callback = options;
+    options = {};
+  }
+
+  if (!callback) {
+    return new Promise(function (resolve, reject) {
+      internals.getPort(options, function (err, port) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(port);
+      });
+    });
+  } else {
+    return internals.getPort(options, callback);
+  }
+};
+
 //
 // ### function getPortPromise (options)
 // #### @options {Object} Settings to use when finding the necessary port
 // Responds a promise to an unbound port on the current machine.
 //
-exports.getPortPromise = function (options) {
-  if (!options) {
-    options = {};
-  }
-  return new Promise(function(resolve, reject) {
-    exports.getPort(options, function(err, port) {
-      if (err) {
-        return reject(err);
-      }
-      resolve(port);
-    });
-  });
-}
+exports.getPortPromise = exports.getPort;
 
-//
-// ### function getPorts (count, options, callback)
-// #### @count {Number} The number of ports to find
-// #### @options {Object} Settings to use when finding the necessary port
-// #### @callback {function} Continuation to respond to when complete.
-// Responds with an array of unbound ports on the current machine.
-//
-exports.getPorts = function (count, options, callback) {
+internals.getPorts = function (count, options, callback) {
   if (!callback) {
     callback = options;
     options = {};
@@ -270,24 +270,39 @@ exports.getPorts = function (count, options, callback) {
 };
 
 //
+// ### function getPorts (count, options, callback)
+// #### @count {Number} The number of ports to find
+// #### @options {Object} Settings to use when finding the necessary port
+// #### @callback {function} Continuation to respond to when complete.
+// Responds with an array of unbound ports on the current machine.
+//
+exports.getPorts = function (count, options, callback) {
+  if (!callback) {
+    callback = options;
+    options = {};
+  }
+
+  if (!callback) {
+    return new Promise(function(resolve, reject) {
+      internals.getPorts(count, options, function(err, ports) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(ports);
+      });
+    });
+  } else {
+    return internals.getPorts(count, options, callback);
+  }
+};
+
+//
 // ### function getPortPromise (options)
 // #### @count {Number} The number of ports to find
 // #### @options {Object} Settings to use when finding the necessary port
 // Responds with a promise that resolves to an array of unbound ports on the current machine.
 //
-exports.getPortsPromise = function (count, options) {
-  if (!options) {
-    options = {};
-  }
-  return new Promise(function(resolve, reject) {
-    exports.getPorts(count, options, function(err, ports) {
-      if (err) {
-        return reject(err);
-      }
-      resolve(ports);
-    });
-  });
-}
+exports.getPortsPromise = exports.getPorts;
 
 //
 // ### function getSocket (options, callback)

--- a/test/port-finder-multiple.test.js
+++ b/test/port-finder-multiple.test.js
@@ -40,8 +40,11 @@ describe('with no existing servers', function () {
     });
   });
 
-  test('the getPortPromises() method with an argument of 3 should respond with the first three available ports (32768, 32769, 32770)', function (done) {
-    portfinder.getPortsPromise(3)
+  test.each([
+    ['getPorts()', portfinder.getPorts],
+    ['getPortsPromise()', portfinder.getPortsPromise],
+  ])('the %s promise method with an argument of 3 should respond with the first three available ports (32768, 32769, 32770)', function (name, method, done) {
+    method(3)
       .then(function (ports) {
         expect(ports).toEqual([32768, 32769, 32770]);
         done();

--- a/test/port-finder.test.js
+++ b/test/port-finder.test.js
@@ -61,6 +61,20 @@ describe('with 5 existing servers', function () {
       done();
     });
   });
+
+  test.each([
+    ['getPort()', portfinder.getPort],
+    ['getPortPromise()', portfinder.getPortPromise],
+  ])('the %s promise method should respond with the first free port (32773)', function (name, method, done) {
+    method()
+      .then(function (port) {
+        expect(port).toEqual(32773);
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+  });
 });
 
 describe('with no existing servers', function () {
@@ -76,8 +90,11 @@ describe('with no existing servers', function () {
     });
   });
 
-  test('the getPortPromise() method should respond with a promise of first free port (32768)', function (done) {
-    portfinder.getPortPromise()
+  test.each([
+    ['getPort()', portfinder.getPort],
+    ['getPortPromise()', portfinder.getPortPromise],
+  ])('the %s promise method should respond with a promise of first free port (32768)', function (name, method, done) {
+    method()
       .then(function (port) {
         expect(port).toEqual(32768);
         done();


### PR DESCRIPTION
Closes #166 

PR makes it so that calling the `getPort` or `getPorts` method without providing a callback will have them return a promise instead. This makes the library more similar to others that support both a callback and a promise interface, without needing extra functions.

The `getPortPromise` and `getPortsPromise` methods are retained for backwards compatibility, but may wish to mark them as deprecated via jsdoc so that people move to using `getPort` and `getPorts`.