### PR TITLE
Fix returning promise with passing options

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -124,11 +124,6 @@ exports.setBasePath = function (path) {
 };
 
 internals.getPort = function (options, callback) {
-  if (!callback) {
-    callback = options;
-    options = {};
-  }
-
   options.port   = Number(options.port) || Number(exports.basePort);
   options.host   = options.host    || null;
   options.stopPort = Number(options.stopPort) || Number(exports.highestPort);
@@ -139,7 +134,7 @@ internals.getPort = function (options, callback) {
       throw Error('Provided options.startPort(' + options.startPort + ') is less than 0, which are cannot be bound.');
     }
     if(options.stopPort < options.startPort) {
-      throw Error('Provided options.stopPort(' + options.stopPort + 'is less than options.startPort (' + options.startPort + ')');
+      throw Error('Provided options.stopPort(' + options.stopPort + ') is less than options.startPort (' + options.startPort + ')');
     }
   }
 
@@ -182,7 +177,7 @@ internals.getPort = function (options, callback) {
         } else {
           const idx = exports._defaultHosts.indexOf(currentHost);
           exports._defaultHosts.splice(idx, 1);
-          return exports.getPort(options, callback);
+          return internals.getPort(options, callback);
         }
       } else {
         // error is not accounted for, file ticket, handle special case
@@ -208,7 +203,7 @@ internals.getPort = function (options, callback) {
       }
     } else {
       // otherwise, try again, using sorted port, aka, highest open for >= 1 host
-      return exports.getPort({ port: openPorts.pop(), host: options.host, startPort: options.startPort, stopPort: options.stopPort }, callback);
+      return internals.getPort({ port: openPorts.pop(), host: options.host, startPort: options.startPort, stopPort: options.stopPort }, callback);
     }
 
   });
@@ -220,10 +215,12 @@ internals.getPort = function (options, callback) {
 // Responds with a unbound port on the current machine.
 //
 exports.getPort = function (options, callback) {
-  if (!callback) {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }
+
+  options = options || {};
 
   if (!callback) {
     return new Promise(function (resolve, reject) {
@@ -247,18 +244,13 @@ exports.getPort = function (options, callback) {
 exports.getPortPromise = exports.getPort;
 
 internals.getPorts = function (count, options, callback) {
-  if (!callback) {
-    callback = options;
-    options = {};
-  }
-
   let lastPort = null;
   _async.timesSeries(count, function(index, asyncCallback) {
     if (lastPort) {
       options.port = exports.nextPort(lastPort);
     }
 
-    exports.getPort(options, function (err, port) {
+    internals.getPort(options, function (err, port) {
       if (err) {
         asyncCallback(err);
       } else {
@@ -277,10 +269,12 @@ internals.getPorts = function (count, options, callback) {
 // Responds with an array of unbound ports on the current machine.
 //
 exports.getPorts = function (count, options, callback) {
-  if (!callback) {
+  if (typeof options === 'function') {
     callback = options;
     options = {};
   }
+
+  options = options || {};
 
   if (!callback) {
     return new Promise(function(resolve, reject) {

--- a/test/port-finder-multiple.test.js
+++ b/test/port-finder-multiple.test.js
@@ -22,35 +22,84 @@ describe('with 5 existing servers', function () {
     helper.stopServers(servers, done);
   });
 
-  test('the getPorts() method with an argument of 3 should respond with the first three available ports (32773, 32774, 32775)', function (done) {
-    portfinder.getPorts(3, function (err, ports) {
-      expect(err).toBeNull();
-      expect(ports).toEqual([32773, 32774, 32775]);
-      done();
+  describe.each([
+    ['getPorts()', false, portfinder.getPorts],
+    ['getPorts()', true, portfinder.getPorts],
+    ['getPortsPromise()', true, portfinder.getPortsPromise],
+  ])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+    test('with an argument of 3 should respond with the first three available ports (32773, 32774, 32775)', function (done) {
+      if (isPromise) {
+        method(3)
+          .then(function (ports) {
+            expect(ports).toEqual([32773, 32774, 32775]);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method(3, function (err, ports) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(ports).toEqual([32773, 32774, 32775]);
+          done();
+        });
+      }
+    });
+
+    test('with stopPort smaller than 3 available ports', function (done) {
+      if (isPromise) {
+        method(3, { stopPort: 32774 })
+          .then(function () {
+            done('Expected error to be thrown');
+          })
+          .catch(function (err) {
+            expect(err).not.toBeNull();
+            expect(err.message).toEqual('No open ports found in between 32768 and 32774');
+            done();
+          });
+      } else {
+        method(3, { stopPort: 32774 }, function (err, ports) {
+          expect(err).not.toBeNull();
+          expect(err.message).toEqual('No open ports found in between 32768 and 32774');
+          expect(ports).toEqual([32773, 32774, undefined]);
+          done();
+        });
+      }
     });
   });
 });
 
 describe('with no existing servers', function () {
-  test('the getPorts() method with an argument of 3 should respond with the first three available ports (32768, 32769, 32770)', function (done) {
-    portfinder.getPorts(3, function (err, ports) {
-      expect(err).toBeNull();
-      expect(ports).toEqual([32768, 32769, 32770]);
-      done();
+  describe.each([
+    ['getPorts()', false, portfinder.getPorts],
+    ['getPorts()', true, portfinder.getPorts],
+    ['getPortsPromise()', true, portfinder.getPortsPromise],
+  ])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+    test('with an argument of 3 should respond with the first three available ports (32768, 32769, 32770)', function (done) {
+      if (isPromise) {
+        method(3)
+          .then(function (ports) {
+            expect(ports).toEqual([32768, 32769, 32770]);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method(3, function (err, ports) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(ports).toEqual([32768, 32769, 32770]);
+          done();
+        });
+      }
     });
-  });
-
-  test.each([
-    ['getPorts()', portfinder.getPorts],
-    ['getPortsPromise()', portfinder.getPortsPromise],
-  ])('the %s promise method with an argument of 3 should respond with the first three available ports (32768, 32769, 32770)', function (name, method, done) {
-    method(3)
-      .then(function (ports) {
-        expect(ports).toEqual([32768, 32769, 32770]);
-        done();
-      })
-      .catch(function (err) {
-        done(err);
-      });
   });
 });

--- a/test/port-finder.test.js
+++ b/test/port-finder.test.js
@@ -22,94 +22,162 @@ describe('with 5 existing servers', function () {
     helper.stopServers(servers, done);
   });
 
-  test('should respond with the first free port (32773)', function (done) {
-    // closeServers(); // close all the servers first!
-    portfinder.getPort(function (err, port) {
-      expect(err).toBeNull();
-      expect(port).toEqual(32773);
-      done();
-    });
-  });
-
-  test('the getPort() method with user passed duplicate host', function (done) {
-    portfinder.getPort({ host: 'localhost' }, function (err, port) {
-      expect(err).toBeNull();
-      expect(port).toEqual(32773);
-      done();
-    });
-  });
-
-  test('the getPort() method with stopPort smaller than available port', function (done) {
-    // stopPort: 32722 is smaller than available port 32773 (32768 + 5)
-    portfinder.getPort({ stopPort: 32772 }, function (err, port) {
-      expect(err).not.toBeNull();
-      expect(err.message).toEqual('No open ports found in between 32768 and 32772');
-      expect(port).toBeUndefined();
-      done();
-    });
-  });
-
-  test('should respond with the first free port (32773) less than provided stopPort', function (done) {
-    // stopPort: 32774 is greater than available port 32773 (32768 + 5)
-    portfinder.getPort({ stopPort: 32774 }, function (err, port) {
-      if (err) {
-        done(err);
-        return;
+  describe.each([
+    ['getPort()', false, portfinder.getPort],
+    ['getPort()', true, portfinder.getPort],
+    ['getPortPromise()', true, portfinder.getPortPromise],
+  ])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+    test('should respond with the first free port (32773)', function (done) {
+      if (isPromise) {
+        method()
+          .then(function (port) {
+            expect(port).toEqual(32773);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method(function (err, port) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(port).toEqual(32773);
+          done();
+        });
       }
-      expect(err).toBeNull();
-      expect(port).toEqual(32773);
-      done();
     });
-  });
 
-  test.each([
-    ['getPort()', portfinder.getPort],
-    ['getPortPromise()', portfinder.getPortPromise],
-  ])('the %s promise method should respond with the first free port (32773)', function (name, method, done) {
-    method()
-      .then(function (port) {
-        expect(port).toEqual(32773);
-        done();
-      })
-      .catch(function (err) {
-        done(err);
-      });
+    test('with user passed duplicate host', function (done) {
+      if (isPromise) {
+        method({ host: 'localhost' })
+          .then(function (port) {
+            expect(port).toEqual(32773);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method({ host: 'localhost' }, function (err, port) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(port).toEqual(32773);
+          done();
+        });
+      }
+    });
+
+    test('with stopPort smaller than available port', function (done) {
+      // stopPort: 32772 is smaller than available port 32773 (32768 + 5)
+      if (isPromise) {
+        method({ stopPort: 32772 })
+          .then(function () {
+            done('Expected error to be thrown');
+          })
+          .catch(function (err) {
+            expect(err).not.toBeNull();
+            expect(err.message).toEqual('No open ports found in between 32768 and 32772');
+            done();
+          });
+      } else {
+        method({ stopPort: 32772 }, function (err, port) {
+          expect(err).not.toBeNull();
+          expect(err.message).toEqual('No open ports found in between 32768 and 32772');
+          expect(port).toBeUndefined();
+          done();
+        });
+      }
+    });
+
+    test('should respond with the first free port (32773) less than provided stopPort', function (done) {
+      // stopPort: 32774 is greater than available port 32773 (32768 + 5)
+      if (isPromise) {
+        method({ stopPort: 32774 })
+          .then(function (port) {
+            expect(port).toEqual(32773);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method({ stopPort: 32774 }, function (err, port) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(port).toEqual(32773);
+          done();
+        });
+      }
+    });
   });
 });
 
 describe('with no existing servers', function () {
-  test('should respond with the first free port (32768)', function (done) {
-    portfinder.getPort(function (err, port) {
-      if (err) {
-        done(err);
-        return;
+  describe.each([
+    ['getPort()', false, portfinder.getPort],
+    ['getPort()', true, portfinder.getPort],
+    ['getPortPromise()', true, portfinder.getPortPromise],
+  ])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+    test('should respond with the first free port (32768)', function (done) {
+      if (isPromise) {
+        method()
+          .then(function (port) {
+            expect(port).toEqual(32768);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      } else {
+        method(function (err, port) {
+          if (err) {
+            done(err);
+            return;
+          }
+          expect(err).toBeNull();
+          expect(port).toEqual(32768);
+          done();
+        });
       }
-      expect(err).toBeNull();
-      expect(port).toEqual(32768);
-      done();
     });
-  });
-
-  test.each([
-    ['getPort()', portfinder.getPort],
-    ['getPortPromise()', portfinder.getPortPromise],
-  ])('the %s promise method should respond with a promise of first free port (32768)', function (name, method, done) {
-    method()
-      .then(function (port) {
-        expect(port).toEqual(32768);
-        done();
-      })
-      .catch(function (err) {
-        done(err);
-      });
   });
 });
 
-test('the getPort() method with startPort less than or equal to 80', function (done) {
-  portfinder.getPort({ startPort: 80 }, function (err, port) {
-    expect(err).toBeNull();
-    expect(port).toBeGreaterThanOrEqual(80);
-    done();
+describe.each([
+  ['getPort()', false, portfinder.getPort],
+  ['getPort()', true, portfinder.getPort],
+  ['getPortPromise()', true, portfinder.getPortPromise],
+])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+  test('with startPort less than or equal to 80', function (done) {
+    if (isPromise) {
+      method({ startPort: 80 })
+        .then(function (port) {
+          expect(port).toBeGreaterThanOrEqual(80);
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    } else {
+      method({ startPort: 80 }, function (err, port) {
+        if (err) {
+          done(err);
+          return;
+        }
+        expect(err).toBeNull();
+        expect(port).toBeGreaterThanOrEqual(80);
+        done();
+      });
+    }
   });
 });
 
@@ -122,12 +190,30 @@ describe('with no available ports above the start port', function () {
     helper.stopServers(servers, done);
   });
 
-  test('the getPort() method requesting an unavailable port', function (done) {
-    portfinder.getPort({ port: 65530 }, function (err, port) {
-      expect(err).not.toBeNull();
-      expect(err.message).toEqual('No open ports available');
-      expect(port).toBeUndefined();
-      done();
+  describe.each([
+    ['getPort()', false, portfinder.getPort],
+    ['getPort()', true, portfinder.getPort],
+    ['getPortPromise()', true, portfinder.getPortPromise],
+  ])(`the %s method (promise: %p)`, function (name, isPromise, method) {
+    test('the getPort() method requesting an unavailable port', function (done) {
+      if (isPromise) {
+        method({ port: 65530 })
+          .then(function () {
+            done('Expected error to be thrown');
+          })
+          .catch(function (err) {
+            expect(err).not.toBeNull();
+            expect(err.message).toEqual('No open ports available');
+            done();
+          });
+      } else {
+        method({ port: 65530 }, function (err, port) {
+          expect(err).not.toBeNull();
+          expect(err.message).toEqual('No open ports available');
+          expect(port).toBeUndefined();
+          done();
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
PR fixes a bug introduced by #168 where when passing `options` to the `getPort` or `getPorts` function and no callback, then the options object would be assigned to the callback, and the whole thing would break.

As part of this, I've refactored the test suite so that all `getPort` and `getPorts` tests are now called for the callback and promise variants of the functions.