### PR TITLE
Update error message: output port at which port finder failed

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -198,7 +198,7 @@ internals.getPort = function (options, callback) {
         return callback(null, openPorts[0]);
       }
       else {
-        const msg = 'No open ports found in between '+ options.startPort + ' and ' + options.stopPort;
+        const msg = `Searching for an open port failed at port ${openPorts[0]}.`;
         return callback(Error(msg));
       }
     } else {

--- a/test/port-finder-multiple.test.js
+++ b/test/port-finder-multiple.test.js
@@ -58,14 +58,14 @@ describe('with 5 existing servers', function () {
           })
           .catch(function (err) {
             expect(err).not.toBeNull();
-            expect(err.message).toEqual('No open ports found in between 32768 and 32774');
+            expect(err.message).toEqual('Searching for an open port failed at port 32775.');
             done();
           });
       } else {
         method(3, { stopPort: 32774 }, function (err, ports) {
           expect(err).not.toBeNull();
-          expect(err.message).toEqual('No open ports found in between 32768 and 32774');
-          expect(ports).toEqual([32773, 32774, undefined]);
+          expect(err.message).toEqual('Searching for an open port failed at port 32775.');
+          expect(ports).toEqual([32773, 32774, undefined]); // Failed at port 32775
           done();
         });
       }

--- a/test/port-finder.test.js
+++ b/test/port-finder.test.js
@@ -82,13 +82,13 @@ describe('with 5 existing servers', function () {
           })
           .catch(function (err) {
             expect(err).not.toBeNull();
-            expect(err.message).toEqual('No open ports found in between 32768 and 32772');
+            expect(err.message).toEqual('Searching for an open port failed at port 32773.');
             done();
           });
       } else {
         method({ stopPort: 32772 }, function (err, port) {
           expect(err).not.toBeNull();
-          expect(err.message).toEqual('No open ports found in between 32768 and 32772');
+          expect(err.message).toEqual('Searching for an open port failed at port 32773.');
           expect(port).toBeUndefined();
           done();
         });


### PR DESCRIPTION
Update error message: output port at which port finder failed

First attempt to modernize error messages for both callback and promise, and make them more accurate on failure.