### PR TITLE
Add promise return for getSocket

### DIFF
--- a/lib/portfinder.d.ts
+++ b/lib/portfinder.d.ts
@@ -28,6 +28,20 @@ interface PortFinderOptions {
   stopPort?: number;
 }
 
+type SocketfinderCallback = (err: Error, socket: string) => void;
+
+interface SocketFinderOptions {
+  /**
+   * Mode to use when creating folder for socket if it doesn't exist
+   */
+  mod?: number;
+  /**
+   * Path to the socket file to create
+   * (defaults to `${exports.basePath}.sock` if not provided)
+   */
+  path?: string;
+}
+
 /**
  * The lowest port to begin any port search from.
  */
@@ -81,3 +95,9 @@ export function getPorts(count: number, options: PortFinderOptions, callback: (e
  * Responds a promise that resolves to an array of unbound ports on the current machine.
  */
 export function getPortsPromise(count: number, options?: PortFinderOptions): Promise<Array<number>>;
+
+export function getSocket(options: SocketFinderOptions): Promise<string>;
+export function getSocket(callback: SocketfinderCallback): void;
+export function getSocket(options: SocketFinderOptions, callback: SocketfinderCallback): void;
+
+export function getSocketPromise(options?: SocketFinderOptions): Promise<string>;

--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -232,7 +232,7 @@ exports.getPort = function (options, callback) {
       });
     });
   } else {
-    return internals.getPort(options, callback);
+    internals.getPort(options, callback);
   }
 };
 
@@ -286,7 +286,7 @@ exports.getPorts = function (count, options, callback) {
       });
     });
   } else {
-    return internals.getPorts(count, options, callback);
+    internals.getPorts(count, options, callback);
   }
 };
 
@@ -298,19 +298,7 @@ exports.getPorts = function (count, options, callback) {
 //
 exports.getPortsPromise = exports.getPorts;
 
-//
-// ### function getSocket (options, callback)
-// #### @options {Object} Settings to use when finding the necessary port
-// #### @callback {function} Continuation to respond to when complete.
-// Responds with a unbound socket using the specified directory and base
-// name on the current machine.
-//
-exports.getSocket = function (options, callback) {
-  if (!callback) {
-    callback = options;
-    options = {};
-  }
-
+internals.getSocket = function (options, callback) {
   options.mod  = options.mod    || parseInt(755, 8);
   options.path = options.path   || exports.basePath + '.sock';
 
@@ -337,7 +325,7 @@ exports.getSocket = function (options, callback) {
         // next socket.
         //
         options.path = exports.nextSocket(options.path);
-        exports.getSocket(options, callback);
+        internals.getSocket(options, callback);
       }
     });
   }
@@ -385,6 +373,37 @@ exports.getSocket = function (options, callback) {
     ? testSocket()
     : checkAndTestSocket();
 };
+
+//
+// ### function getSocket (options, callback)
+// #### @options {Object} Settings to use when finding the necessary port
+// #### @callback {function} Continuation to respond to when complete.
+// Responds with a unbound socket using the specified directory and base
+// name on the current machine.
+//
+exports.getSocket = function (options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  options = options || {};
+
+  if (!callback) {
+    return new Promise(function (resolve, reject) {
+      internals.getSocket(options, function (err, socketPath) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(socketPath);
+      });
+    });
+  } else {
+    internals.getSocket(options, callback);
+  }
+}
+
+exports.getSocketPromise = exports.getSocket;
 
 //
 // ### function nextPort (port)


### PR DESCRIPTION
Closes #169 

Adds a promise return for `getSocket` as well as `getSocketPromise` function, so as to match the `getPort` and `getPorts` functions. Also adds type information for these functions as that was totally missing before.

The overall tests that are run remain the same, just that they're run against all three variants as was setup in #172.