### PR TITLE
Return callback error vs throwing

### DIFF
--- a/lib/portfinder.js
+++ b/lib/portfinder.js
@@ -128,13 +128,13 @@ internals.getPort = function (options, callback) {
   options.host   = options.host    || null;
   options.stopPort = Number(options.stopPort) || Number(exports.highestPort);
 
-  if(!options.startPort) {
-    options.startPort = Number(options.port);
-    if(options.startPort < 0) {
-      throw Error('Provided options.startPort(' + options.startPort + ') is less than 0, which are cannot be bound.');
+  if (!options.startPort) {
+    options.startPort = options.port;
+    if (options.startPort < 0) {
+      return callback(Error(`Provided options.port(${options.port}) is less than 0, which are cannot be bound.`));
     }
-    if(options.stopPort < options.startPort) {
-      throw Error('Provided options.stopPort(' + options.stopPort + ') is less than options.startPort (' + options.startPort + ')');
+    if (options.stopPort < options.startPort) {
+      return callback(Error(`Provided options.stopPort(${options.stopPort}) is less than options.port(${options.startPort})`));
     }
   }
 

--- a/test/port-finder.test.js
+++ b/test/port-finder.test.js
@@ -227,3 +227,21 @@ describe('with no available ports above the start port', function () {
     });
   });
 });
+
+test('should return error if port is negative', function (done) {
+  portfinder.getPort({ port: -1 }, function (err, port) {
+    expect(err).not.toBeNull();
+    expect(err.message).toEqual('Provided options.port(-1) is less than 0, which are cannot be bound.');
+    expect(port).toBeUndefined();
+    done();
+  });
+});
+
+test('should return error if port is less than stopPort', function (done) {
+  portfinder.getPort({ port: 32768, stopPort: 32767 }, function (err, port) {
+    expect(err).not.toBeNull();
+    expect(err.message).toEqual('Provided options.stopPort(32767) is less than options.port(32768)');
+    expect(port).toBeUndefined();
+    done();
+  });
+});


### PR DESCRIPTION
Fixes #171 

PR makes it so that instead of having `getPort` throw errors in some cases, it'll instead return an error on the callback. This allows for a singular error handling necessary for end users (namely around the callback), vs requiring them to both worry about the callback as well as wrapping the `getPort` call in a try/catch.

I think that there's more options validation that could happen here (e.g. if `options.startPort` is provided, should probably have similar checks), but that can be done in a follow-up once this pattern is established on how to return errors to the user.